### PR TITLE
Removes duplicated addition of universal income every timestep

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -412,8 +412,6 @@ class Agent:
         self.timestep = timestep
         # Prevent dead or already moved agent from moving
         if self.alive == True and self.cell != None and self.lastMoved != self.timestep:
-            self.sugar += self.universalSugar
-            self.spice += self.universalSpice
             self.lastSugar = self.sugar
             self.lastSpice = self.spice
             self.lastMoved = self.timestep


### PR DESCRIPTION
self.sugar += self.universalSugar and self.spice += self.universalSpice are already present in doUniversalIncome() which is called in doTimestep(). Based on the time interval logic in doUniversalIncome(), it doesn’t seem like universalSugar and universalSpice should be added every single timestep in addition to the call to doUniversalIncome().