### PR TITLE
Replaces insertion sort and reverse with reverse order insertion sort

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -611,7 +611,7 @@ class Agent:
         if len(cells) == 0:
             return None
         bestCell = None
-        cells = self.sortCellsByWealthDescending(cells)
+        cells = self.sortCellsByWealth(cells)
         if "all" in self.debug or "agent" in self.debug:
             self.printCellScores(cells)
         # If not an ethical agent, return top selfish choice
@@ -663,7 +663,7 @@ class Agent:
 
         # If additional ordering consideration, select new best cell
         if "Top" in self.decisionModel:
-            cells = self.sortCellsByWealthDescending(cells)
+            cells = self.sortCellsByWealth(cells)
             if "all" in self.debug or "agent" in self.debug:
                 self.printEthicalCellScores(cells)
             bestCell = cells[0]["cell"]
@@ -1219,7 +1219,7 @@ class Agent:
         sugarscape = self.cell.environment.sugarscape
         sugarscape.addDisease(disease, agent)
 
-    def sortCellsByWealthDescending(self, cells):
+    def sortCellsByWealth(self, cells):
         # Insertion sort of cells by wealth in descending order with range as a tiebreaker
         i = 0
         while i < len(cells):

--- a/agent.py
+++ b/agent.py
@@ -611,8 +611,7 @@ class Agent:
         if len(cells) == 0:
             return None
         bestCell = None
-        cells = self.sortCellsByWealth(cells)
-        cells.reverse()
+        cells = self.sortCellsByWealthDescending(cells)
         if "all" in self.debug or "agent" in self.debug:
             self.printCellScores(cells)
         # If not an ethical agent, return top selfish choice
@@ -664,8 +663,7 @@ class Agent:
 
         # If additional ordering consideration, select new best cell
         if "Top" in self.decisionModel:
-            cells = self.sortCellsByWealth(cells)
-            cells.reverse()
+            cells = self.sortCellsByWealthDescending(cells)
             if "all" in self.debug or "agent" in self.debug:
                 self.printEthicalCellScores(cells)
             bestCell = cells[0]["cell"]
@@ -1221,12 +1219,12 @@ class Agent:
         sugarscape = self.cell.environment.sugarscape
         sugarscape.addDisease(disease, agent)
 
-    def sortCellsByWealth(self, cells):
-        # Insertion sort of cells by wealth with range as a tiebreaker
+    def sortCellsByWealthDescending(self, cells):
+        # Insertion sort of cells by wealth in descending order with range as a tiebreaker
         i = 0
         while i < len(cells):
             j = i
-            while j > 0 and (cells[j - 1]["wealth"] > cells[j]["wealth"] or (cells[j - 1]["wealth"] == cells[j]["wealth"] and cells[j - 1]["range"] <= cells[j]["range"])):
+            while j > 0 and (cells[j - 1]["wealth"] < cells[j]["wealth"] or (cells[j - 1]["wealth"] == cells[j]["wealth"] and cells[j - 1]["range"] >= cells[j]["range"])):
                 currCell = cells[j]
                 cells[j] = cells[j - 1]
                 cells[j - 1] = currCell

--- a/agent.py
+++ b/agent.py
@@ -1224,7 +1224,7 @@ class Agent:
         i = 0
         while i < len(cells):
             j = i
-            while j > 0 and (cells[j - 1]["wealth"] < cells[j]["wealth"] or (cells[j - 1]["wealth"] == cells[j]["wealth"] and cells[j - 1]["range"] >= cells[j]["range"])):
+            while j > 0 and (cells[j - 1]["wealth"] < cells[j]["wealth"] or (cells[j - 1]["wealth"] == cells[j]["wealth"] and cells[j - 1]["range"] > cells[j]["range"])):
                 currCell = cells[j]
                 cells[j] = cells[j - 1]
                 cells[j - 1] = currCell


### PR DESCRIPTION
Whenever sortCellsByWealth() is called, reverse() is called immediately after. Sorting the cells in reverse order in the first place is more efficient. This commit removes the sortCellsByWealth() function, replaces it with sortCellsByWealthDescending() (which sorts in descending order), and replaces two instances of calls to sortCellsByWealth() and then reverse() with sortCellsByWealthDescending().