### PR TITLE
Improves benthamHalfLookaheadValueOfCell() efficiency by ~40%

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -893,12 +893,7 @@ class Agent:
                 neighborhood.append(neighbor)
         neighborhood.append(self)
         if newCell == None:
-            # Shuffle cells for movement considerations
-            random.shuffle(allCells)
             self.neighborhood = neighborhood
-        # This neighborhood should not be used for movement,
-        # only for calculating len(agent.findNeighborhood(cell))
-        # in *HalfLookahead decision models.
         return neighborhood
 
     def findNewMarginalRateOfSubstitution(self, sugar, spice):

--- a/agent.py
+++ b/agent.py
@@ -700,8 +700,6 @@ class Agent:
             allCells = self.cell.environment.findCellsInRange(cell.x, cell.y, cellRange)
             if newCell == None:
                 self.cellsInRange = allCells
-            # Shuffle cells for movement considerations
-            random.shuffle(allCells)
             return allCells
         return []
 
@@ -895,7 +893,12 @@ class Agent:
                 neighborhood.append(neighbor)
         neighborhood.append(self)
         if newCell == None:
+            # Shuffle cells for movement considerations
+            random.shuffle(allCells)
             self.neighborhood = neighborhood
+        # This neighborhood should not be used for movement,
+        # only for calculating len(agent.findNeighborhood(cell))
+        # in *HalfLookahead decision models.
         return neighborhood
 
     def findNewMarginalRateOfSubstitution(self, sugar, spice):


### PR DESCRIPTION
In my test using benthamHalfLookaheadTop, 75% of findBenthamHalfLookaheadValueOfCell() runtime is taken up by one call to agent.findNeighborhood(cell) which is then passed to len(agent.findNeighborhood(cell)). 80% of the call to agent.findNeighborhood(cell) is self.findCellsInRange(newCell), and 60% of that is shuffling. For this specific use case, there is no need to shuffle — you just want the size of the neighborhood at the next cell.

findNeighborhood() is called 4 times in the repository:
- at the top of findBestCell(), with no parameter, so newCell == None. This changes self.neighborhood so it should shuffle before returning.
- once in each *HalfLookaheadValueOfCell() for a total of 3 calls, with a cell parameter, so newCell != None. The return values from these 3 are only used to find a length, so the lists do not need to be shuffled.

findCellsInRange() is only used for findNeighborhood(). I've moved the shuffle() from findCellsInRange() to the "if newCell == None" block in findNeighborhood(). This will also improve all other *HalfLookaheadValueOfCell() functions by a similar percentage, but I didn't test them all individually. In my testing, the change seems to speed up benthamHalfLookaheadTop total simulation runtimes by 30%.