### PR TITLE
Moves instantiation of all cells from addSugarPeak() and addSpicePeak()…

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -1,5 +1,6 @@
 import math
 import random
+import cell
 
 class Environment:
     # Assumption: grid is always indexed by [height][width]
@@ -28,8 +29,14 @@ class Environment:
         self.universalSpiceIncomeInterval = configuration["universalSpiceIncomeInterval"]
         self.universalSugarIncomeInterval = configuration["universalSugarIncomeInterval"]
         self.equator = math.ceil(self.height / 2)
-        # Populate grid with NoneType objects
-        self.grid = [[None for j in range(width)]for i in range(height)]
+        # Populate grid with default Cell objects
+        self.grid = [[cell.Cell(i, j, self) for j in range(width)] for i in range(height)]
+        seasons = True if configuration["seasonInterval"] > 0 else False
+        if seasons == True:
+            for i in range(self.height):
+                for j in range(self.width):
+                    self.grid[i][j].season = self.seasonNorth if j >= self.equator else self.seasonSouth
+
 
     def doCellUpdate(self):
         for i in range(self.height):
@@ -95,9 +102,6 @@ class Environment:
             cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
             cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
         return cellsInRange
-
-    def placeCell(self, cell, x, y):
-        self.grid[x][y] = cell
 
     def resetCell(self, x, y):
         self.grid[x][y] = None

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -971,7 +971,5 @@ if __name__ == "__main__":
         for stat in memoryStats[:100]:
             print(stat)
     else:
-        print("Timesteps: ", configuration["timesteps"])
-        print("Model: ", configuration["agentDecisionModel"])
         S.runSimulation(configuration["timesteps"])
     exit(0)

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -69,17 +69,8 @@ class Sugarscape:
         height = self.environment.height
         width = self.environment.width
         radialDispersion = math.sqrt(max(startX, width - startX)**2 + max(startY, height - startY)**2) * (radius / width)
-        seasons = True if self.configuration["environmentSeasonInterval"] > 0 else False
         for i in range(height):
             for j in range(width):
-                if self.environment.findCell(i, j) == None:
-                    newCell = cell.Cell(i, j, self.environment)
-                    if seasons == True:
-                        if j >= self.environment.equator:
-                            newCell.season = "summer"
-                        else:
-                            newCell.season = "winter"
-                    self.environment.placeCell(newCell, i, j)
                 euclideanDistanceToStart = math.sqrt((startX - i)**2 + (startY - j)**2)
                 currDispersion = 1 + maxSpice * (1 - euclideanDistanceToStart / radialDispersion)
                 cellMaxCapacity = min(currDispersion, maxSpice)
@@ -92,17 +83,8 @@ class Sugarscape:
         height = self.environment.height
         width = self.environment.width
         radialDispersion = math.sqrt(max(startX, width - startX)**2 + max(startY, height - startY)**2) * (radius / width)
-        seasons = True if self.configuration["environmentSeasonInterval"] > 0 else False
         for i in range(height):
             for j in range(width):
-                if self.environment.findCell(i, j) == None:
-                    newCell = cell.Cell(i, j, self.environment)
-                    if seasons == True:
-                        if j >= self.environment.equator:
-                            newCell.season = "summer"
-                        else:
-                            newCell.season = "winter"
-                    self.environment.placeCell(newCell, i, j)
                 euclideanDistanceToStart = math.sqrt((startX - i)**2 + (startY - j)**2)
                 currDispersion = 1 + maxSugar * (1 - euclideanDistanceToStart / radialDispersion)
                 cellMaxCapacity = min(currDispersion, maxSugar)
@@ -989,5 +971,7 @@ if __name__ == "__main__":
         for stat in memoryStats[:100]:
             print(stat)
     else:
+        print("Timesteps: ", configuration["timesteps"])
+        print("Model: ", configuration["agentDecisionModel"])
         S.runSimulation(configuration["timesteps"])
     exit(0)


### PR DESCRIPTION
…to Environment constructor, removes now unused placeCell() definition.

The Environment constructor currently fills grid with Nones, and addSugarPeak() and addSpicePeak() both have checks to instantiate default Cells outside of the peak shape if self.environment.findCell(i, j) == None. addSugarPeak() and addSpicePeak() should only add sugar and spice peaks as it says in their names, not create the empty grid cells too. It doesn't make sense to replace grid Nones with Cells in both addSugarPeak() and addSpicePeak(). It's more intuitive to instantiate the Cell objects in the Environment constructor.

*I did have to import cell to environment, but I think that makes sense given that grid stores Cells.