### PR TITLE
Changes decisionModel string in config options to decisionModels list of models

### DIFF
--- a/README
+++ b/README
@@ -104,10 +104,12 @@ agentBaseInterestRate: [float, float]
     Set the interest rate for an agent's lending as a percentage.
     Default: [0.0, 0.0]
 
-agentDecisionModel: string
-    Set the agent decision model for different decisionmaking.
+agentDecisionModel: [string, ...]
+    Set the agent decision models for different decisionmaking.
     Options: "altruisticHalfLookaheadBinary", "altruisticHalfLookaheadTop", "benthamHalfLookaheadBinary", "benthamHalfLookaheadTop", "benthamNoLookaheadBinary", "benthamNoLookaheadTop", "egoisticHalfLookaheadBinary", "egoisticHalfLookaheadTop", "none", "rawSugarscape"
     Default: "none"
+    Note: Can select multiple decision models simultaneuously and include the same decision
+          model multiple times. The relative frequency of a decision model in the starting population will be equal to its relative frequency in this list.
 
 agentDecisionModelData: object
     Set additional data for the agent decision model.

--- a/README
+++ b/README
@@ -108,8 +108,7 @@ agentDecisionModel: [string, ...]
     Set the agent decision models for different decisionmaking.
     Options: "altruisticHalfLookaheadBinary", "altruisticHalfLookaheadTop", "benthamHalfLookaheadBinary", "benthamHalfLookaheadTop", "benthamNoLookaheadBinary", "benthamNoLookaheadTop", "egoisticHalfLookaheadBinary", "egoisticHalfLookaheadTop", "none", "rawSugarscape"
     Default: "none"
-    Note: Can select multiple decision models simultaneuously and include the same decision
-          model multiple times. The relative frequency of a decision model in the starting population will be equal to its relative frequency in this list.
+    Note: Can select multiple decision models simultaneuously and include the same decision model multiple times. The relative frequency of a decision model in the starting population will be equal to its relative frequency in this list.
 
 agentDecisionModelData: object
     Set additional data for the agent decision model.

--- a/config.json
+++ b/config.json
@@ -14,7 +14,7 @@
         "__README__": "Default values for Sugarscape simulation provided here. Details can be found in the README.",
         "agentAggressionFactor": [1, 1],
         "agentBaseInterestRate": [0.05, 0.10],
-        "agentDecisionModel": "none",
+        "agentDecisionModel": ["none"],
         "agentDecisionModelData": {},
         "agentDecisionModelFactor": [1, 1],
         "agentFemaleInfertilityAge": [40, 50],

--- a/data/run.py
+++ b/data/run.py
@@ -16,15 +16,18 @@ def createConfigurations(config, path):
         seeds = generateSeeds(dataOpts)
         confFiles = []
         for seed in seeds:
-            for model in dataOpts["decisionModels"]:
+            for modelList in dataOpts["decisionModels"]:
                 simOpts = config["sugarscapeOptions"]
-                simOpts["agentEthicalTheory"] = model
+                # Ensure compatibility with both strings and lists of strings
+                if isinstance(modelList, str):
+                    modelList = [modelList]
+                simOpts["agentDecisionModels"] = modelList
                 simOpts["seed"] = seed
-                simOpts["logfile"] = "{0}{1}{2}.json".format(path, model, seed)
+                simOpts["logfile"] = "{0}{1}{2}.json".format(path, modelList, seed)
                 # Enforce noninteractive, no-output mode
                 simOpts["headlessMode"] = True
                 simOpts["debugMode"] = ["none"]
-                confFilePath = "{0}{1}{2}.config".format(path, model, seed)
+                confFilePath = "{0}{1}{2}.config".format(path, modelList, seed)
                 confFiles.append(confFilePath)
                 conf = open(confFilePath, 'w')
                 conf.write(json.dumps(simOpts))

--- a/data/run.py
+++ b/data/run.py
@@ -155,6 +155,10 @@ if __name__ == "__main__":
     config = json.loads(configFile.read())
     configFile.close()
 
+    if "dataCollectionOptions" not in config:
+        print("Configuration file must have specific data collection options in order to run automated data collection.")
+        exit(1)
+
     configFiles = createConfigurations(config, path)
     runSimulations(config, configFiles, path)
 

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -421,10 +421,11 @@ class Sugarscape:
         inheritancePolicy = configs["agentInheritancePolicy"]
         decisionModelFactor = configs["agentDecisionModelFactor"]
         selfishnessFactor = configs["agentSelfishnessFactor"]
-        decisionModel = configs["agentDecisionModel"]
-        # Convert clever name for default behavior
-        if decisionModel == "rawSugarscape":
-            decisionModel = "none"
+        decisionModels = [
+            # Convert clever name for default behavior
+            "none" if model == "rawSugarscape" else model
+            for model in configs["agentDecisionModel"]
+        ]
         universalSpice = configs["agentUniversalSpice"]
         universalSugar = configs["agentUniversalSugar"]
 
@@ -520,12 +521,18 @@ class Sugarscape:
         for config in configurations:
             random.seed(self.agentConfigHashes[config] + self.timestep)
             random.shuffle(configurations[config]["endowments"])
+
         random.setstate(randomNumberReset)
         random.shuffle(sexes)
+        # Calculate number of models beforehand to avoid repeated len() calls
+        numDecisionModels = len(decisionModels)
         for i in range(numAgents):
+            # Randomize decision model order but maintain correct relative frequencies by cycling through model list
+            if numDecisionModels > 1 and i % numDecisionModels == 0:
+                    random.shuffle(decisionModels)
             agentEndowment = {"seed": self.seed, "sex": sexes[i], "tags": tags.pop(),
                               "immuneSystem": immuneSystems.pop(), "inheritancePolicy": inheritancePolicy,
-                              "decisionModel": decisionModel}
+                              "decisionModel": decisionModels[i % numDecisionModels]}
             for config in configurations:
                 # If sexes are enabled, ensure proper fertility and infertility ages are set
                 if sexes[i] == "female" and config == "femaleFertilityAge":
@@ -869,10 +876,6 @@ def verifyConfiguration(configuration):
     if configuration["environmentMaxTribes"] > 11:
         configuration["environmentMaxTribes"] = 11
 
-    # Keep compatibility with outdated configuration files
-    if configuration["agentDecisionModel"] == "rawSugarscape":
-        configuration["agentDecisionModel"] = "none"
-
     if len(configuration["agentStartingQuadrants"]) == 0:
         configuration["agentStartingQuadrants"] = [1, 2, 3, 4]
 
@@ -909,7 +912,7 @@ if __name__ == "__main__":
     # Set default values for simulation configuration
     configuration = {"agentAggressionFactor": [0, 0],
                      "agentBaseInterestRate": [0.0, 0.0],
-                     "agentDecisionModel": "none",
+                     "agentDecisionModel": ["none"],
                      "agentDecisionModelFactor": [0, 0],
                      "agentFemaleInfertilityAge": [0, 0],
                      "agentFemaleFertilityAge": [0, 0],


### PR DESCRIPTION
**Progress made on** #21 

Updates:
- README: updates information
- config.json: changes string to list
- sugarscape.py: changes decisionModel string to decisionModels list, **randomizeAgentEndowments() randomly picks from decisionModels for each agent but in separate cycles to maintain correct relative frequencies**

TODO:
- rename all occurrences of decisionModel config option to decisionModels
- check to see impact on data collection
- thoroughly test for bugs