### PR TITLE
Fixes indentation and loop logic in findEthicalValueOfCell()?

### DIFF
--- a/ethics.py
+++ b/ethics.py
@@ -149,28 +149,28 @@ class Egoist(agent.Agent):
         for neighbor in self.neighborhood:
             if neighbor.canReachCell(cell) == True:
                 canSee += 1
-
-        for neighbor in self.neighborhood:
-            timestepDistance = 1
-            neighborMetabolism = neighbor.sugarMetabolism + neighbor.spiceMetabolism
-            cellDuration = cellSiteWealth / neighborMetabolism if neighborMetabolism > 0 else 0
-            certainty = 1 if neighbor.canReachCell(cell) == True else 0
-            proximity = 1 / timestepDistance
-            intensity = (1 / (1 + neighbor.findTimeToLive()) / (1 + cell.pollution))
-            duration = cellDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
-            # Agent discount, futureDuration, and futureIntensity implement Bentham's purity and fecundity
-            discount = 0.5
-            futureDuration = (cellSiteWealth - neighborMetabolism) / neighborMetabolism if neighborMetabolism > 0 else cellSiteWealth
-            futureDuration = futureDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
-            futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
-            futureExtent = len(self.findNeighborhood(cell)) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
-            # Assuming agent can only see in four cardinal directions
-            extent = canSee / (neighbor.vision * 4) if neighbor.vision > 0 else 1
-            if self.lookahead == None:
-                neighborValueOfCell = neighbor.decisionModelFactor * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
-            else:
-                neighborValueOfCell = neighbor.decisionModelFactor * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
-            cellValue += neighborValueOfCell
+        timestepDistance = 1
+        totalMetabolism = self.sugarMetabolism + self.spiceMetabolism
+        cellDuration = cellSiteWealth / totalMetabolism if totalMetabolism > 0 else 0
+        
+        # Assuming agent can only see in four cardinal directions
+        extent = canSee / (self.vision * 4) if self.vision > 0 else 1
+        # Agent can always reach cell
+        certainty = 1
+        proximity = 1 / timestepDistance
+        intensity = (1 / (1 + self.findTimeToLive()) / (1 + cell.pollution))
+        duration = cellDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
+        # Agent discount, futureDuration, and futureIntensity implement Bentham's purity and fecundity
+        discount = 0.5
+        futureDuration = (cellSiteWealth - totalMetabolism) / totalMetabolism if totalMetabolism > 0 else cellSiteWealth
+        futureDuration = futureDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
+        futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
+        
+        if self.lookahead == None:
+            cellValue = self.decisionModelFactor * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
+        else:
+            futureExtent = len(self.findNeighborhood(cell)) / (self.vision * 4) if self.vision > 0 and self.lookahead != None else 1
+            cellValue = self.decisionModelFactor * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
         return cellValue
 
     def spawnChild(self, childID, birthday, cell, configuration):

--- a/ethics.py
+++ b/ethics.py
@@ -149,26 +149,28 @@ class Egoist(agent.Agent):
         for neighbor in self.neighborhood:
             if neighbor.canReachCell(cell) == True:
                 canSee += 1
-        timestepDistance = 1
-        neighborMetabolism = neighbor.sugarMetabolism + neighbor.spiceMetabolism
-        cellDuration = cellSiteWealth / neighborMetabolism if neighborMetabolism > 0 else 0
-        certainty = 1 if neighbor.canReachCell(cell) == True else 0
-        proximity = 1 / timestepDistance
-        intensity = (1 / (1 + neighbor.findTimeToLive()) / (1 + cell.pollution))
-        duration = cellDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
-        # Agent discount, futureDuration, and futureIntensity implement Bentham's purity and fecundity
-        discount = 0.5
-        futureDuration = (cellSiteWealth - neighborMetabolism) / neighborMetabolism if neighborMetabolism > 0 else cellSiteWealth
-        futureDuration = futureDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
-        futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
-        futureExtent = len(self.findNeighborhood(cell)) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
-        # Assuming agent can only see in four cardinal directions
-        extent = canSee / (neighbor.vision * 4) if neighbor.vision > 0 else 1
-        if self.lookahead == None:
-            neighborValueOfCell = neighbor.decisionModelFactor * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
-        else:
-            neighborValueOfCell = neighbor.decisionModelFactor * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
-        cellValue += neighborValueOfCell
+
+        for neighbor in self.neighborhood:
+            timestepDistance = 1
+            neighborMetabolism = neighbor.sugarMetabolism + neighbor.spiceMetabolism
+            cellDuration = cellSiteWealth / neighborMetabolism if neighborMetabolism > 0 else 0
+            certainty = 1 if neighbor.canReachCell(cell) == True else 0
+            proximity = 1 / timestepDistance
+            intensity = (1 / (1 + neighbor.findTimeToLive()) / (1 + cell.pollution))
+            duration = cellDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
+            # Agent discount, futureDuration, and futureIntensity implement Bentham's purity and fecundity
+            discount = 0.5
+            futureDuration = (cellSiteWealth - neighborMetabolism) / neighborMetabolism if neighborMetabolism > 0 else cellSiteWealth
+            futureDuration = futureDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
+            futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
+            futureExtent = len(self.findNeighborhood(cell)) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
+            # Assuming agent can only see in four cardinal directions
+            extent = canSee / (neighbor.vision * 4) if neighbor.vision > 0 else 1
+            if self.lookahead == None:
+                neighborValueOfCell = neighbor.decisionModelFactor * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
+            else:
+                neighborValueOfCell = neighbor.decisionModelFactor * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
+            cellValue += neighborValueOfCell
         return cellValue
 
     def spawnChild(self, childID, birthday, cell, configuration):


### PR DESCRIPTION
This change is purely based on the fact that `Egoist findEthicalValueOfCell()` is calling `neighbor` outside of the `for neighbor in self.neighborhood` loop, which doesn't seem right to me. I put the `canSee` sum in a separate loop because it seems like it's only supposed to be used in the main loop after it's fully calculated. `canSee` is used for calculating `extent` for each `neighbor`, but to be honest, I'm not sure what `extent` is doing inside of the loop. I thought it was indicated by the summing of each `neighborValueOfCell` into `cellValue`. `canSee` is one of the only differences between the `findEthicalValueOfCell()` in `Egoist` and the one in `Bentham`, which just uses `len(self.neighborhood)` to calculate `extent`.