### PR TITLE
Improves findCellsInRadialRange efficiency and implements wraparound

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -96,14 +96,17 @@ class Environment:
             cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
         return cellsInRange
 
-    # TODO: fix this brutally inefficient means of finding all cells within a Euclidean distance
     def findCellsInRadialRange(self, startX, startY, gridRange):
         cellsInRange = []
-        for i in range(self.height):
-            for j in range(self.width):
+        # Iterate through the bounding box of the circle
+        for i in range(startX - gridRange, startX + gridRange + 1):
+            for j in range(startY - gridRange, startY + gridRange + 1):
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 if euclideanDistance < gridRange + 1:
-                    cellsInRange.append({"cell": self.grid[i][j], "distance": euclideanDistance})
+                    # Use mod to include wraparound behavior
+                    wrappedI = (i + self.height) % self.height
+                    wrappedJ = (j + self.width) % self.width
+                    cellsInRange.append({"cell": self.grid[wrappedI][wrappedJ], "distance": euclideanDistance})
         return cellsInRange
 
     def resetCell(self, x, y):


### PR DESCRIPTION
Should result in a massive improvement — instead of checking 50x50 = 2500 cells for the default configuration, you only need to check 1x1 = 1 up to 13x13 = 169 cells. This commit also gives findCellsInRadialRange the wraparound behavior that is already present in findCellsInCardinalRange.