### PR TITLE
Doubles efficiency of findCellsInRadialRange

### DIFF
--- a/environment.py
+++ b/environment.py
@@ -84,7 +84,7 @@ class Environment:
                 self.grid[i][j].findNeighbors()
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
-        cellsInRange = []
+        cellsInRange = [{"cell": self.grid[startX][startY], "distance": 0}]
         for i in range(1, gridRange + 1):
             deltaNorth = (startY + i + self.height) % self.height
             deltaSouth = (startY - i + self.height) % self.height
@@ -97,17 +97,26 @@ class Environment:
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
-        cellsInRange = []
-        # Iterate through the bounding box of the circle
-        for i in range(startX - gridRange, startX + gridRange + 1):
-            for j in range(startY - gridRange, startY + gridRange + 1):
-                euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
-                # If agent can see at least part of a cell, they should be allowed to consider it
-                if euclideanDistance < gridRange + 1:
-                    deltaX = (i + self.height) % self.height
-                    deltaY = (j + self.width) % self.width
-                    cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
-        return cellsInRange
+    cellsInRange = []
+    # Iterate through the upper left quadrant of the circle's bounding box
+    for i in range(startX - gridRange, startX):
+        for j in range(startY - gridRange, startY):
+            euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
+            # If agent can see at least part of a cell, they should be allowed to consider it
+            if euclideanDistance < gridRange + 1:
+                # Append cells in the top left quadrant
+                deltaX = (i + self.height) % self.height
+                deltaY = (j + self.width) % self.width
+                cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
+                # Reflect to the other three quadrants
+                reflectedX = (2 * startX - i + self.height) % self.height
+                reflectedY = (2 * startY - j + self.width) % self.width
+                cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
+                cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
+                cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})
+    # Include cardinal cells in between quadrants
+    cellsInRange += self.findCellsInCardinalRange(startX, startY, gridRange)
+    return cellsInRange
 
     def resetCell(self, x, y):
         self.grid[x][y] = None

--- a/environment.py
+++ b/environment.py
@@ -85,13 +85,11 @@ class Environment:
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []
-        height = self.height
-        width = self.width
         for i in range(1, gridRange + 1):
-            deltaNorth = (startY + i + height) % height
-            deltaSouth = (startY - i + height) % height
-            deltaEast = (startX + i + width) % width
-            deltaWest = (startX - i + width) % width
+            deltaNorth = (startY + i + self.height) % self.height
+            deltaSouth = (startY - i + self.height) % self.height
+            deltaEast = (startX + i + self.width) % self.width
+            deltaWest = (startX - i + self.width) % self.width
             cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
             cellsInRange.append({"cell": self.grid[startX][deltaSouth], "distance": i})
             cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
@@ -100,18 +98,16 @@ class Environment:
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
         cellsInRange = self.findCellsInCardinalRange(startX, startY, gridRange)
-        height = self.height
-        width = self.width
         # Iterate through the upper left quadrant of the circle's bounding box
         for i in range(startX - gridRange, startX):
             for j in range(startY - gridRange, startY):
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 # If agent can see at least part of a cell, they should be allowed to consider it
                 if euclideanDistance < gridRange + 1:
-                    deltaX = (i + height) % height
-                    reflectedX = (2 * startX - i + height) % height
-                    deltaY = (j + width) % width
-                    reflectedY = (2 * startY - j + width) % width
+                    deltaX = (i + self.height) % self.height
+                    reflectedX = (2 * startX - i + self.height) % self.height
+                    deltaY = (j + self.width) % self.width
+                    reflectedY = (2 * startY - j + self.width) % self.width
                     cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
                     cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
                     cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})

--- a/environment.py
+++ b/environment.py
@@ -88,10 +88,13 @@ class Environment:
         height = self.height
         width = self.width
         for i in range(1, gridRange + 1):
-            deltaXs = [(startX + i + width) % width, (startX - i + width) % width]
-            deltaYs = [(startY + i + height) % height, (startY - i + height) % height]
-            cellsInRange.extend([{"cell": self.grid[startX][y], "distance": i} for y in deltaYs])
-            cellsInRange.extend([{"cell": self.grid[x][startY], "distance": i} for x in deltaXs])
+            deltaNorth, deltaSouth = (startY + i + height) % height, (startY - i + height) % height
+            deltaEast, deltaWest = (startX + i + width) % width, (startX - i + width) % width
+            cellsInRange.extend([
+                {"cell": self.grid[startX][deltaNorth], "distance": i},
+                {"cell": self.grid[startX][deltaSouth], "distance": i},
+                {"cell": self.grid[deltaEast][startY], "distance": i},
+                {"cell": self.grid[deltaWest][startY], "distance": i}])
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
@@ -104,11 +107,13 @@ class Environment:
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 # If agent can see at least part of a cell, they should be allowed to consider it
                 if euclideanDistance < gridRange + 1:
-                    deltaXs = [(i + height) % height, (2 * startX - i + height) % height]
-                    deltaYs = [(j + width) % width, (2 * startY - j + width) % width]
+                    deltaX, reflectedX = (i + height) % height, (2 * startX - i + height) % height
+                    deltaY, reflectedY = (j + width) % width, (2 * startY - j + width) % width
                     cellsInRange.extend([
-                        {"cell": self.grid[x][y], "distance": euclideanDistance} 
-                        for x in deltaXs for y in deltaYs])
+                        {"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance},
+                        {"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance},
+                        {"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance},
+                        {"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance}])
         return cellsInRange
 
     def resetCell(self, x, y):

--- a/environment.py
+++ b/environment.py
@@ -97,26 +97,26 @@ class Environment:
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
-    cellsInRange = []
-    # Iterate through the upper left quadrant of the circle's bounding box
-    for i in range(startX - gridRange, startX):
-        for j in range(startY - gridRange, startY):
-            euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
-            # If agent can see at least part of a cell, they should be allowed to consider it
-            if euclideanDistance < gridRange + 1:
-                # Append cells in the top left quadrant
-                deltaX = (i + self.height) % self.height
-                deltaY = (j + self.width) % self.width
-                cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
-                # Reflect to the other three quadrants
-                reflectedX = (2 * startX - i + self.height) % self.height
-                reflectedY = (2 * startY - j + self.width) % self.width
-                cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
-                cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
-                cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})
-    # Include cardinal cells in between quadrants
-    cellsInRange += self.findCellsInCardinalRange(startX, startY, gridRange)
-    return cellsInRange
+        cellsInRange = []
+        # Iterate through the upper left quadrant of the circle's bounding box
+        for i in range(startX - gridRange, startX):
+            for j in range(startY - gridRange, startY):
+                euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
+                # If agent can see at least part of a cell, they should be allowed to consider it
+                if euclideanDistance < gridRange + 1:
+                    # Append cells in the top left quadrant
+                    deltaX = (i + self.height) % self.height
+                    deltaY = (j + self.width) % self.width
+                    cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
+                    # Reflect to the other three quadrants
+                    reflectedX = (2 * startX - i + self.height) % self.height
+                    reflectedY = (2 * startY - j + self.width) % self.width
+                    cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
+                    cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
+                    cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})
+        # Include cardinal cells in between quadrants
+        cellsInRange += self.findCellsInCardinalRange(startX, startY, gridRange)
+        return cellsInRange
 
     def resetCell(self, x, y):
         self.grid[x][y] = None

--- a/environment.py
+++ b/environment.py
@@ -96,6 +96,8 @@ class Environment:
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
         cellsInRange = self.findCellsInCardinalRange(startX, startY, gridRange)
+        # Current cell shouldn't be included, but we want to maintain current behavior for now
+        cellsInRange.append({"cell": self.grid[startX][startY], "distance": 0})
         height = self.height
         width = self.width
         # Iterate through the upper left quadrant of the circle's bounding box

--- a/environment.py
+++ b/environment.py
@@ -84,19 +84,14 @@ class Environment:
                 self.grid[i][j].findNeighbors()
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
-        cellsInRange = [{"cell": self.grid[startX][startY], "distance": 0}]
+        cellsInRange = []
         height = self.height
         width = self.width
         for i in range(1, gridRange + 1):
-            deltaNorth = (startY + i + height) % height
-            deltaSouth = (startY - i + height) % height
-            deltaEast = (startX + i + width) % width
-            deltaWest = (startX - i + width) % width
-            cellsInRange.extend([
-                {"cell": self.grid[startX][deltaNorth], "distance": i},
-                {"cell": self.grid[startX][deltaSouth], "distance": i},
-                {"cell": self.grid[deltaEast][startY], "distance": i},
-                {"cell": self.grid[deltaWest][startY], "distance": i}])
+            deltaXs = [(startX + i + width) % width, (startX - i + width) % width]
+            deltaYs = [(startY + i + height) % height, (startY - i + height) % height]
+            cellsInRange.extend([{"cell": self.grid[startX][y], "distance": i} for y in deltaYs])
+            cellsInRange.extend([{"cell": self.grid[x][startY], "distance": i} for x in deltaXs])
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
@@ -109,17 +104,11 @@ class Environment:
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 # If agent can see at least part of a cell, they should be allowed to consider it
                 if euclideanDistance < gridRange + 1:
-                    # Coordinates for the top left quadrant
-                    deltaX = (i + height) % height
-                    deltaY = (j + width) % width
-                    # Reflected coordinates for the other three quadrants
-                    reflectedX = (2 * startX - i + height) % height
-                    reflectedY = (2 * startY - j + width) % width
+                    deltaXs = [(i + height) % height, (2 * startX - i + height) % height]
+                    deltaYs = [(j + width) % width, (2 * startY - j + width) % width]
                     cellsInRange.extend([
-                        {"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance},
-                        {"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance},
-                        {"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance},
-                        {"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance}])
+                        {"cell": self.grid[x][y], "distance": euclideanDistance} 
+                        for x in deltaXs for y in deltaYs])
         return cellsInRange
 
     def resetCell(self, x, y):

--- a/environment.py
+++ b/environment.py
@@ -88,13 +88,14 @@ class Environment:
         height = self.height
         width = self.width
         for i in range(1, gridRange + 1):
-            deltaNorth, deltaSouth = (startY + i + height) % height, (startY - i + height) % height
-            deltaEast, deltaWest = (startX + i + width) % width, (startX - i + width) % width
-            cellsInRange.extend([
-                {"cell": self.grid[startX][deltaNorth], "distance": i},
-                {"cell": self.grid[startX][deltaSouth], "distance": i},
-                {"cell": self.grid[deltaEast][startY], "distance": i},
-                {"cell": self.grid[deltaWest][startY], "distance": i}])
+            deltaNorth = (startY + i + height) % height
+            deltaSouth = (startY - i + height) % height
+            deltaEast = (startX + i + width) % width
+            deltaWest = (startX - i + width) % width
+            cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
+            cellsInRange.append({"cell": self.grid[startX][deltaSouth], "distance": i})
+            cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
+            cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
@@ -107,13 +108,14 @@ class Environment:
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 # If agent can see at least part of a cell, they should be allowed to consider it
                 if euclideanDistance < gridRange + 1:
-                    deltaX, reflectedX = (i + height) % height, (2 * startX - i + height) % height
-                    deltaY, reflectedY = (j + width) % width, (2 * startY - j + width) % width
-                    cellsInRange.extend([
-                        {"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance},
-                        {"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance},
-                        {"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance},
-                        {"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance}])
+                    deltaX = (i + height) % height
+                    reflectedX = (2 * startX - i + height) % height
+                    deltaY = (j + width) % width
+                    reflectedY = (2 * startY - j + width) % width
+                    cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
+                    cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
+                    cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
+                    cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})
         return cellsInRange
 
     def resetCell(self, x, y):

--- a/environment.py
+++ b/environment.py
@@ -85,37 +85,41 @@ class Environment:
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = [{"cell": self.grid[startX][startY], "distance": 0}]
+        height = self.height
+        width = self.width
         for i in range(1, gridRange + 1):
-            deltaNorth = (startY + i + self.height) % self.height
-            deltaSouth = (startY - i + self.height) % self.height
-            deltaEast = (startX + i + self.width) % self.width
-            deltaWest = (startX - i + self.width) % self.width
-            cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
-            cellsInRange.append({"cell": self.grid[startX][deltaSouth], "distance": i})
-            cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
-            cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
+            deltaNorth = (startY + i + height) % height
+            deltaSouth = (startY - i + height) % height
+            deltaEast = (startX + i + width) % width
+            deltaWest = (startX - i + width) % width
+            cellsInRange.extend([
+                {"cell": self.grid[startX][deltaNorth], "distance": i},
+                {"cell": self.grid[startX][deltaSouth], "distance": i},
+                {"cell": self.grid[deltaEast][startY], "distance": i},
+                {"cell": self.grid[deltaWest][startY], "distance": i}])
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
-        cellsInRange = []
+        cellsInRange = self.findCellsInCardinalRange(startX, startY, gridRange)
+        height = self.height
+        width = self.width
         # Iterate through the upper left quadrant of the circle's bounding box
         for i in range(startX - gridRange, startX):
             for j in range(startY - gridRange, startY):
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 # If agent can see at least part of a cell, they should be allowed to consider it
                 if euclideanDistance < gridRange + 1:
-                    # Append cells in the top left quadrant
-                    deltaX = (i + self.height) % self.height
-                    deltaY = (j + self.width) % self.width
-                    cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
-                    # Reflect to the other three quadrants
-                    reflectedX = (2 * startX - i + self.height) % self.height
-                    reflectedY = (2 * startY - j + self.width) % self.width
-                    cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
-                    cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
-                    cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})
-        # Include cardinal cells in between quadrants
-        cellsInRange += self.findCellsInCardinalRange(startX, startY, gridRange)
+                    # Coordinates for the top left quadrant
+                    deltaX = (i + height) % height
+                    deltaY = (j + width) % width
+                    # Reflected coordinates for the other three quadrants
+                    reflectedX = (2 * startX - i + height) % height
+                    reflectedY = (2 * startY - j + width) % width
+                    cellsInRange.extend([
+                        {"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance},
+                        {"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance},
+                        {"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance},
+                        {"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance}])
         return cellsInRange
 
     def resetCell(self, x, y):

--- a/environment.py
+++ b/environment.py
@@ -96,8 +96,6 @@ class Environment:
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
         cellsInRange = self.findCellsInCardinalRange(startX, startY, gridRange)
-        # Current cell shouldn't be included, but we want to maintain current behavior for now
-        cellsInRange.append({"cell": self.grid[startX][startY], "distance": 0})
         height = self.height
         width = self.width
         # Iterate through the upper left quadrant of the circle's bounding box


### PR DESCRIPTION
- Circles are symmetrical, so you only need to check the top left quadrant and then you can reflect those cells to the other three quadrants.
- I also included the current cell in `findCellsInCardinalRange` because it's included in `findCellsInRadialRange` and it seems like it should be in range of itself.

I figured radial movement and vision — especially at higher values — would be pretty time intensive for the simulation, so I wanted to make it as efficient as possible. This should help out with #18.