### PR TITLE
Improves overall simulation efficiency by 33%, fixes extent calculation

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -47,7 +47,7 @@ class Agent:
         self.alive = True
         self.age = 0
         self.cellsInRange = []
-        self.neighborhood = []
+        self.neighborhood = set()
         self.lastMoved = -1
         self.vonNeumannNeighbors = {"north": None, "south": None, "east": None, "west": None}
         self.mooreNeighbors = {"north": None, "northeast": None, "northwest": None, "south": None, "southeast": None, "southwest": None, "east": None, "west": None}
@@ -84,6 +84,7 @@ class Agent:
         self.visionModifier = 0
         self.aggressionFactorModifier = 0
         self.fertilityFactorModifier = 0
+        self.findNeighborhood()
 
     def addChildToCell(self, mate, cell, childConfiguration):
         sugarscape = self.cell.environment.sugarscape
@@ -852,12 +853,12 @@ class Agent:
 
     def findNeighborhood(self, newCell=None):
         newNeighborhood = self.findCellsInRange(newCell)
-        neighborhood = []
+        neighborhood = set()
         for neighborCell in newNeighborhood:
             neighbor = neighborCell["cell"].agent
             if neighbor != None and neighbor.isAlive() == True:
-                neighborhood.append(neighbor)
-        neighborhood.append(self)
+                neighborhood.add(neighbor)
+        neighborhood.add(self)
         if newCell == None:
             self.neighborhood = neighborhood
         return neighborhood

--- a/ethics.py
+++ b/ethics.py
@@ -17,6 +17,7 @@ class Bentham(agent.Agent):
         globalMaxWealth = cell.environment.globalMaxSugar + cell.environment.globalMaxSpice
         cellValue = 0
         selfishnessFactor = self.selfishnessFactor
+        futureNeighborhood = self.findNeighborhood(cell)
         for neighbor in self.neighborhood:
             # Timesteps to reach cell, currently 1 since agents only plan for the current timestep
             timestepDistance = 1
@@ -32,9 +33,8 @@ class Bentham(agent.Agent):
             futureDuration = (cellSiteWealth - neighborMetabolism) / neighborMetabolism if neighborMetabolism > 0 else cellSiteWealth
             futureDuration = futureDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
             futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
-            # Assuming agent can only see in four cardinal directions
-            extent = len(self.neighborhood) / (neighbor.vision * 4) if neighbor.vision > 0 else 1
-            futureExtent = len(self.findNeighborhood(cell)) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
+            neighborsNeighborhoodSize = len(neighbor.neighborhood)
+            extent = len(self.neighborhood & neighbor.neighborhood) / neighborsNeighborhoodSize
             neighborValueOfCell = 0
             # If not the agent moving, consider these as opportunity costs
             if neighbor != self and cell != neighbor.cell and self.selfishnessFactor < 1:
@@ -45,12 +45,14 @@ class Bentham(agent.Agent):
                 if self.lookahead == None:
                     neighborValueOfCell = neighbor.decisionModelFactor * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
                 else:
+                    futureExtent = len(futureNeighborhood & neighbor.neighborhood) / neighborsNeighborhoodSize
                     neighborValueOfCell = neighbor.decisionModelFactor * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
             # If move will kill this neighbor, consider this a penalty
             elif neighbor != self and cell == neighbor.cell and self.selfishnessFactor < 1:
                 if self.lookahead == None:
                     neighborValueOfCell = -1 * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
                 else:
+                    futureExtent = len(futureNeighborhood & neighbor.neighborhood) / neighborsNeighborhoodSize
                     neighborValueOfCell = -1 * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
                 # If penalty is too slight, make it more severe
                 if neighborValueOfCell > -1:
@@ -59,6 +61,7 @@ class Bentham(agent.Agent):
                 if self.lookahead == None:
                     neighborValueOfCell = neighbor.decisionModelFactor * ((extent * certainty * proximity) * ((intensity + duration) + (discount * (futureIntensity + futureDuration))))
                 else:
+                    futureExtent = len(futureNeighborhood & neighbor.neighborhood) / neighborsNeighborhoodSize
                     neighborValueOfCell = neighbor.decisionModelFactor * ((certainty * proximity) * ((extent * (intensity + duration)) + (discount * (futureExtent * (futureIntensity + futureDuration)))))
             if selfishnessFactor != -1:
                 if neighbor == self:


### PR DESCRIPTION
To start off, half of the runtime on the current simulation (with ethical models) is taken up by calls to `self.findNeighborhood(cell)` in the `for neighbor in self.neighborhood` loop in `findEthicalValueOfCell()`. I noticed this does not need to be calculated every iteration of the loop — just once at the beginning. This would improve simulation efficiency by 50%. 

Then I noticed that the calculation it was being used in — `futureExtent` — was not updated to include radial movement and vision, and neither was `extent`. They should both be calculated by finding the proportion of the neighbor's neighborhood that is shared by the current agent's neighborhood (present or future). I changed `neighborhood` to be a set because it's much faster to find shared values in sets. Calculating the shared neighbors for each neighbor is still time intensive, but still much more efficient than the current code.

Overall, this will massively improve efficiency for any decision model that calls `findEthicalValueOfCell()`. In my test, a simulation with 200 timesteps using `benthamHalfLookaheadBinary` that originally took 300 seconds now takes 200 seconds, and all of the time reduction is in `findEthicalValueOfCell()`.