### PR TITLE
Moves neighborhood calculation outside for loop

### DIFF
--- a/ethics.py
+++ b/ethics.py
@@ -17,6 +17,7 @@ class Bentham(agent.Agent):
         globalMaxWealth = cell.environment.globalMaxSugar + cell.environment.globalMaxSpice
         cellValue = 0
         selfishnessFactor = self.selfishnessFactor
+        futureNeighborhood = self.findNeighborhood(cell)
         for neighbor in self.neighborhood:
             # Timesteps to reach cell, currently 1 since agents only plan for the current timestep
             timestepDistance = 1
@@ -34,7 +35,7 @@ class Bentham(agent.Agent):
             futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
             # Assuming agent can only see in four cardinal directions
             extent = len(self.neighborhood) / (neighbor.vision * 4) if neighbor.vision > 0 else 1
-            futureExtent = len(self.findNeighborhood(cell)) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
+            futureExtent = len(futureNeighborhood) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
             neighborValueOfCell = 0
             # If not the agent moving, consider these as opportunity costs
             if neighbor != self and cell != neighbor.cell and self.selfishnessFactor < 1:

--- a/ethics.py
+++ b/ethics.py
@@ -17,7 +17,8 @@ class Bentham(agent.Agent):
         globalMaxWealth = cell.environment.globalMaxSugar + cell.environment.globalMaxSpice
         cellValue = 0
         selfishnessFactor = self.selfishnessFactor
-        futureNeighborhood = self.findNeighborhood(cell)
+        neighborhoodSize = len(self.neighborhood)
+        futureNeighborhoodSize = len(self.findNeighborhood(cell))
         for neighbor in self.neighborhood:
             # Timesteps to reach cell, currently 1 since agents only plan for the current timestep
             timestepDistance = 1
@@ -34,8 +35,8 @@ class Bentham(agent.Agent):
             futureDuration = futureDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
             futureIntensity = cellNeighborWealth / (globalMaxWealth * 4)
             # Assuming agent can only see in four cardinal directions
-            extent = len(self.neighborhood) / (neighbor.vision * 4) if neighbor.vision > 0 else 1
-            futureExtent = len(futureNeighborhood) / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
+            extent = neighborhoodSize / (neighbor.vision * 4) if neighbor.vision > 0 else 1
+            futureExtent = futureNeighborhoodSize / (neighbor.vision * 4) if neighbor.vision > 0 and self.lookahead != None else 1
             neighborValueOfCell = 0
             # If not the agent moving, consider these as opportunity costs
             if neighbor != self and cell != neighbor.cell and self.selfishnessFactor < 1:


### PR DESCRIPTION
Should double overall simulation efficiency for models that call `findEthicalValueOfCell()`.