### PR TITLE
Fixes memory leak by removing old references (first pass)

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -211,6 +211,13 @@ class Agent:
         self.resetCell()
         self.doInheritance()
 
+        # Remove unnecessary references
+        self.socialNetwork = {"debtors": self.socialNetwork["debtors"],
+                              "children": self.socialNetwork["children"]}
+        self.neighborhood = []
+        self.vonNeumannNeighbors = {}
+        self.mooreNeighbors = {}
+
     def doDisease(self):
         diseases = self.diseases
         for diseaseRecord in diseases:

--- a/agent.py
+++ b/agent.py
@@ -211,9 +211,8 @@ class Agent:
         self.resetCell()
         self.doInheritance()
 
-        # Remove unnecessary references
-        self.socialNetwork = {"debtors": self.socialNetwork["debtors"],
-                              "children": self.socialNetwork["children"]}
+        # Keep only debtors and children in social network to handle outstanding loans
+        self.socialNetwork = {"debtors": self.socialNetwork["debtors"], "children": self.socialNetwork["children"]}
         self.neighborhood = []
         self.vonNeumannNeighbors = {}
         self.mooreNeighbors = {}


### PR DESCRIPTION
![memory-profile](https://github.com/nkremerh/sugarscape/assets/118491522/e841c41d-62c9-4c30-8cb4-96760371d28b)
![memory-profile-3](https://github.com/nkremerh/sugarscape/assets/118491522/df837f18-23bd-4396-b1ab-07a6b1c5ddbf)

#17 
Before and after of a memory graph for `benthamHalfLookaheadBinary` over 1K timesteps; it appears to almost flatten out at under 150 MiBs now. I can't test thoroughly over 10K timesteps or multiple models and seeds on my computer, so maybe @nkremerh can see what it looks like.

Some notes:
- I'm not sure what the memory spike at the end is — maybe the garbage collector kicking in, or something related to the memory profiling?
- This fix does appear to slow the simulation down a bit, which is unfortunate. The graph appears to show 120 vs. 220 seconds on my test, which is surprising given how little code is added.
- From my investigation, there are still some objects that shouldn't be in memory anymore, but I think they're now being capped by the population so they're not causing memory leaks.
- I'm certain this maintains determinism; I checked multiple timesteps later in the simulation and everything was the exact same. However, every so often, the statistics at the top will be slightly different, but then they regain parity in the next timestep. I'm not sure what's causing this behavior.
- There is probably a way to make this fix cleaner and better at cleaning up memory. This is a first pass.