### PR TITLE
Adds correct timesteps to make data simulations

### DIFF
--- a/data/run.py
+++ b/data/run.py
@@ -13,6 +13,7 @@ def createConfigurations(config, path):
         if path[-1] != '/':
             path = path + '/'
         dataOpts = config["dataCollectionOptions"]
+        timesteps = dataOpts["plotTimesteps"]
         seeds = generateSeeds(dataOpts)
         confFiles = []
         for seed in seeds:
@@ -20,6 +21,7 @@ def createConfigurations(config, path):
                 simOpts = config["sugarscapeOptions"]
                 simOpts["agentDecisionModel"] = model
                 simOpts["seed"] = seed
+                simOpts["timesteps"] = timesteps
                 simOpts["logfile"] = "{0}{1}{2}.json".format(path, model, seed)
                 # Enforce noninteractive, no-output mode
                 simOpts["headlessMode"] = True


### PR DESCRIPTION
I noticed that my `make data` log files were blowing past the `plotTimesteps` I had set for them. It looks like the intended timesteps from `dataCollectionOptions` are not included in the simulation setups, so they use the default 1000.

As a side note, it might be faster to only log the variables you're intending to plot rather than log all of them and only use the `plots` setting to generate specific plots after the fact. It looks like all variables are being logged right now regardless of whether you're planning to plot them or not. I could fix this if it's a topic of interest.

Also, I had to manually change the `make data` command to python3 instead of python. Should the `make data` command be using the same python alias for running `run.py` that you can set for actually running the simulations in `dataCollectionOptions`?