### PR TITLE
Fully implements option to use Moore neighborhoods

### DIFF
--- a/README
+++ b/README
@@ -99,7 +99,7 @@ JSON Configuration File Options:
 The simulation provides a default set of options in a dictionary in the sugarscape.py file.
 A JSON configuration file can be passed to the simulation, overwriting the default configuration, with the --conf option.
 
-agentAdjacencyMode: string
+adjacencyMode: string
     Set the behavior of agents' adjacency neighborhoods used for tagging, trading, disease, and reproduction.
     Options: "von Neumann", "Moore"
     Default: "von Neumann"

--- a/README
+++ b/README
@@ -99,6 +99,11 @@ JSON Configuration File Options:
 The simulation provides a default set of options in a dictionary in the sugarscape.py file.
 A JSON configuration file can be passed to the simulation, overwriting the default configuration, with the --conf option.
 
+agentAdjacencyMode: string
+    Set the behavior of agents' adjacency neighborhoods used for tagging, trading, disease, and reproduction.
+    Options: "von Neumann", "Moore"
+    Default: "von Neumann"
+
 agentAggressionFactor: [float, float]
     Set the aggressiveness of an agent.
     Note: The more aggressive an agent the more likely they will be enticed by combat options.

--- a/agent.py
+++ b/agent.py
@@ -356,51 +356,55 @@ class Agent:
         # Agent marked for removal or not interested in reproduction should not reproduce
         if self.alive == False or self.isFertile() == False:
             return
-        random.shuffle(self.adjacentNeighbors)
+        random.shuffle(self.cell.adjacentCells)
         emptyCells = self.findEmptyNeighborCells()
-        for neighbor in self.adjacentNeighbors:
-            neighborCompatibility = self.isNeighborReproductionCompatible(neighbor)
-            emptyCellsWithNeighbor = emptyCells + neighbor.findEmptyNeighborCells()
-            random.shuffle(emptyCellsWithNeighbor)
-            if self.isFertile() == True and neighborCompatibility == True and len(emptyCellsWithNeighbor) != 0:
-                emptyCell = emptyCellsWithNeighbor.pop()
-                while emptyCell.agent != None and len(emptyCellsWithNeighbor) != 0:
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
+            if neighbor != None:
+                neighborCompatibility = self.isNeighborReproductionCompatible(neighbor)
+                emptyCellsWithNeighbor = emptyCells + neighbor.findEmptyNeighborCells()
+                random.shuffle(emptyCellsWithNeighbor)
+                if self.isFertile() == True and neighborCompatibility == True and len(emptyCellsWithNeighbor) != 0:
                     emptyCell = emptyCellsWithNeighbor.pop()
-                # If no adjacent empty cell is found, skip reproduction with this neighbor
-                if emptyCell.agent != None:
-                    continue
-                childEndowment = self.findChildEndowment(neighbor)
-                child = self.addChildToCell(neighbor, emptyCell, childEndowment)
-                self.socialNetwork["children"].append(child)
-                childID = child.ID
-                neighborID = neighbor.ID
-                self.addAgentToSocialNetwork(child)
-                neighbor.addAgentToSocialNetwork(child)
-                neighbor.updateTimesVisitedWithAgent(self, self.lastMoved)
-                neighbor.updateTimesReproducedWithAgent(self, self.lastMoved)
-                self.updateTimesReproducedWithAgent(neighbor, self.lastMoved)
-                self.lastReproduced += 1
+                    while emptyCell.agent != None and len(emptyCellsWithNeighbor) != 0:
+                        emptyCell = emptyCellsWithNeighbor.pop()
+                    # If no adjacent empty cell is found, skip reproduction with this neighbor
+                    if emptyCell.agent != None:
+                        continue
+                    childEndowment = self.findChildEndowment(neighbor)
+                    child = self.addChildToCell(neighbor, emptyCell, childEndowment)
+                    self.socialNetwork["children"].append(child)
+                    childID = child.ID
+                    neighborID = neighbor.ID
+                    self.addAgentToSocialNetwork(child)
+                    neighbor.addAgentToSocialNetwork(child)
+                    neighbor.updateTimesVisitedWithAgent(self, self.lastMoved)
+                    neighbor.updateTimesReproducedWithAgent(self, self.lastMoved)
+                    self.updateTimesReproducedWithAgent(neighbor, self.lastMoved)
+                    self.lastReproduced += 1
 
-                sugarCost = self.startingSugar / (self.fertilityFactor * 2)
-                spiceCost = self.startingSpice / (self.fertilityFactor * 2)
-                mateSugarCost = neighbor.startingSugar / (neighbor.fertilityFactor * 2)
-                mateSpiceCost = neighbor.startingSpice / (neighbor.fertilityFactor * 2)
-                self.sugar -= sugarCost
-                self.spice -= spiceCost
-                neighbor.sugar = neighbor.sugar - mateSugarCost
-                neighbor.spice = neighbor.spice - mateSpiceCost
-                self.lastReproduced = self.cell.environment.sugarscape.timestep
-                if "all" in self.debug or "agent" in self.debug:
-                    print("Agent {0} reproduced with agent {1} at cell ({2},{3})".format(self.ID, str(neighbor), emptyCell.x, emptyCell.y))
+                    sugarCost = self.startingSugar / (self.fertilityFactor * 2)
+                    spiceCost = self.startingSpice / (self.fertilityFactor * 2)
+                    mateSugarCost = neighbor.startingSugar / (neighbor.fertilityFactor * 2)
+                    mateSpiceCost = neighbor.startingSpice / (neighbor.fertilityFactor * 2)
+                    self.sugar -= sugarCost
+                    self.spice -= spiceCost
+                    neighbor.sugar = neighbor.sugar - mateSugarCost
+                    neighbor.spice = neighbor.spice - mateSpiceCost
+                    self.lastReproduced = self.cell.environment.sugarscape.timestep
+                    if "all" in self.debug or "agent" in self.debug:
+                        print("Agent {0} reproduced with agent {1} at cell ({2},{3})".format(self.ID, str(neighbor), emptyCell.x, emptyCell.y))
 
     def doTagging(self):
         if self.tags == None or self.alive == False:
             return
-        random.shuffle(self.adjacentNeighbors)
-        for neighbor in self.adjacentNeighbors:
-            position = random.randrange(len(self.tags))
-            neighbor.flipTag(position, self.tags[position])
-            neighbor.tribe = neighbor.findTribe()
+        random.shuffle(self.cell.adjacentCells)
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
+            if neighbor != None:
+                position = random.randrange(len(self.tags))
+                neighbor.flipTag(position, self.tags[position])
+                neighbor.tribe = neighbor.findTribe()
 
     def doTimestep(self, timestep):
         self.timestep = timestep

--- a/agent.py
+++ b/agent.py
@@ -213,8 +213,7 @@ class Agent:
         # Keep only debtors and children in social network to handle outstanding loans
         self.socialNetwork = {"debtors": self.socialNetwork["debtors"], "children": self.socialNetwork["children"]}
         self.neighborhood = []
-        self.vonNeumannNeighbors = {}
-        self.mooreNeighbors = {}
+        self.adjacentNeighbors = []
 
     def doDisease(self):
         diseases = self.diseases

--- a/agent.py
+++ b/agent.py
@@ -306,11 +306,13 @@ class Agent:
         # Maximum interest rate of 100%
         interestRate = min(1, self.lendingFactor * self.baseInterestRate)
         borrowers = []
-        for neighbor in self.adjacentNeighbors:
-            if neighbor.isAlive() == False:
-                continue
-            elif neighbor.isBorrower() == True:
-                borrowers.append(neighbor)
+        for adjacentCell in self.cell.adjacentCells:
+            neighbor = adjacentCell.agent
+            if neighbor != None:
+                if neighbor.isAlive() == False:
+                    continue
+                elif neighbor.isBorrower() == True:
+                    borrowers.append(neighbor)
         random.shuffle(borrowers)
         spiceMetabolism = self.findSpiceMetabolism()
         sugarMetabolism = self.findSugarMetabolism()
@@ -357,12 +359,10 @@ class Agent:
         # Agent marked for removal or not interested in reproduction should not reproduce
         if self.alive == False or self.isFertile() == False:
             return
-        # Copy to maintain determinism with current repo
-        adjacentCells = self.cell.adjacentCells[:]
-        random.shuffle(adjacentCells)
+        random.shuffle(self.cell.adjacentCells)
         emptyCells = self.findEmptyNeighborCells()
-        for neighborCell in adjacentCells:
-            neighbor = neighborCell.agent
+        for adjacentCell in self.cell.adjacentCells:
+            neighbor = adjacentCell.agent
             if neighbor != None:
                 neighborCompatibility = self.isNeighborReproductionCompatible(neighbor)
                 emptyCellsWithNeighbor = emptyCells + neighbor.findEmptyNeighborCells()
@@ -399,11 +399,9 @@ class Agent:
     def doTagging(self):
         if self.tags == None or self.alive == False:
             return
-        # Copy to maintain determinism with current repo
-        adjacentCells = self.cell.adjacentCells[:]
-        random.shuffle(adjacentCells)
-        for neighborCell in adjacentCells:
-            neighbor = neighborCell.agent
+        random.shuffle(self.cell.adjacentCells)
+        for adjacentCell in self.cell.adjacentCells:
+            neighbor = adjacentCell.agent
             if neighbor != None:
                 position = random.randrange(len(self.tags))
                 neighbor.flipTag(position, self.tags[position])
@@ -453,8 +451,9 @@ class Agent:
         self.spicePrice = 0
         self.findMarginalRateOfSubstitution()
         traders = []
-        for neighbor in self.adjacentNeighbors:
-            if neighbor.isAlive() == True:
+        for adjacentCell in self.cell.adjacentCells:
+            neighbor = adjacentCell.agent
+            if neighbor != None and neighbor.isAlive() == True:
                 neighborMRS = neighbor.marginalRateOfSubstitution
                 if neighborMRS != self.marginalRateOfSubstitution:
                     traders.append(neighbor)

--- a/agent.py
+++ b/agent.py
@@ -237,8 +237,9 @@ class Agent:
         if diseaseCount == 0:
             return
         neighbors = []
-        for neighbor in self.adjacentNeighbors:
-            if neighbor.isAlive() == True:
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
+            if neighbor != None and neighbor.isAlive() == True:
                 neighbors.append(neighbor)
         random.shuffle(neighbors)
         for neighbor in neighbors:
@@ -356,9 +357,11 @@ class Agent:
         # Agent marked for removal or not interested in reproduction should not reproduce
         if self.alive == False or self.isFertile() == False:
             return
-        random.shuffle(self.cell.adjacentCells)
+        # Copy to maintain determinism with current repo
+        adjacentCells = self.cell.adjacentCells[:]
+        random.shuffle(adjacentCells)
         emptyCells = self.findEmptyNeighborCells()
-        for neighborCell in self.cell.adjacentCells:
+        for neighborCell in adjacentCells:
             neighbor = neighborCell.agent
             if neighbor != None:
                 neighborCompatibility = self.isNeighborReproductionCompatible(neighbor)
@@ -374,8 +377,6 @@ class Agent:
                     childEndowment = self.findChildEndowment(neighbor)
                     child = self.addChildToCell(neighbor, emptyCell, childEndowment)
                     self.socialNetwork["children"].append(child)
-                    childID = child.ID
-                    neighborID = neighbor.ID
                     self.addAgentToSocialNetwork(child)
                     neighbor.addAgentToSocialNetwork(child)
                     neighbor.updateTimesVisitedWithAgent(self, self.lastMoved)
@@ -398,8 +399,10 @@ class Agent:
     def doTagging(self):
         if self.tags == None or self.alive == False:
             return
-        random.shuffle(self.cell.adjacentCells)
-        for neighborCell in self.cell.adjacentCells:
+        # Copy to maintain determinism with current repo
+        adjacentCells = self.cell.adjacentCells[:]
+        random.shuffle(adjacentCells)
+        for neighborCell in adjacentCells:
             neighbor = neighborCell.agent
             if neighbor != None:
                 position = random.randrange(len(self.tags))

--- a/agent.py
+++ b/agent.py
@@ -306,8 +306,8 @@ class Agent:
         # Maximum interest rate of 100%
         interestRate = min(1, self.lendingFactor * self.baseInterestRate)
         borrowers = []
-        for adjacentCell in self.cell.adjacentCells:
-            neighbor = adjacentCell.agent
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
             if neighbor != None:
                 if neighbor.isAlive() == False:
                     continue
@@ -361,8 +361,8 @@ class Agent:
             return
         random.shuffle(self.cell.adjacentCells)
         emptyCells = self.findEmptyNeighborCells()
-        for adjacentCell in self.cell.adjacentCells:
-            neighbor = adjacentCell.agent
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
             if neighbor != None:
                 neighborCompatibility = self.isNeighborReproductionCompatible(neighbor)
                 emptyCellsWithNeighbor = emptyCells + neighbor.findEmptyNeighborCells()
@@ -400,8 +400,8 @@ class Agent:
         if self.tags == None or self.alive == False:
             return
         random.shuffle(self.cell.adjacentCells)
-        for adjacentCell in self.cell.adjacentCells:
-            neighbor = adjacentCell.agent
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
             if neighbor != None:
                 position = random.randrange(len(self.tags))
                 neighbor.flipTag(position, self.tags[position])
@@ -451,8 +451,8 @@ class Agent:
         self.spicePrice = 0
         self.findMarginalRateOfSubstitution()
         traders = []
-        for adjacentCell in self.cell.adjacentCells:
-            neighbor = adjacentCell.agent
+        for neighborCell in self.cell.adjacentCells:
+            neighbor = neighborCell.agent
             if neighbor != None and neighbor.isAlive() == True:
                 neighborMRS = neighbor.marginalRateOfSubstitution
                 if neighborMRS != self.marginalRateOfSubstitution:
@@ -782,8 +782,7 @@ class Agent:
 
     def findEmptyNeighborCells(self):
         emptyCells = []
-        neighborCells = self.cell.adjacentCells
-        for neighborCell in neighborCells:
+        for neighborCell in self.cell.adjacentCells:
             if neighborCell.agent == None:
                 emptyCells.append(neighborCell)
         return emptyCells

--- a/agent.py
+++ b/agent.py
@@ -1268,7 +1268,7 @@ class Agent:
     def updateAdjacentNeighbors(self):
         adjacentNeighbors = []
         for adjacentCell in self.cell.adjacentCells:
-            if adjacentCell != None and adjacentCell.agent != None:
+            if adjacentCell.agent != None:
                 adjacentNeighbors.append(adjacentCell.agent)
         self.adjacentNeighbors = adjacentNeighbors
 

--- a/cell.py
+++ b/cell.py
@@ -14,7 +14,7 @@ class Cell:
         self.hemisphere = "north" if self.x >= self.environment.equator else "south"
         self.season = None
         self.timestep = 0
-        self.adjacentCells = set()
+        self.adjacentCells = []
         self.sugarLastProduced = 0
         self.spiceLastProduced = 0
 

--- a/cell.py
+++ b/cell.py
@@ -28,11 +28,11 @@ class Cell:
 
     def doPollutionDiffusion(self):
         meanPollution = self.pollution
-        for neighbor in self.neighbors:
-            meanPollution += neighbor.pollution
-        meanPollution = meanPollution / (len(self.neighbors) + 1)
-        for neighbor in self.neighbors:
-            neighbor.pollution = meanPollution
+        for adjacentCell in self.adjacentCells:
+            meanPollution += adjacentCell.pollution
+        meanPollution = meanPollution / (len(self.adjacentCells) + 1)
+        for adjacentCell in self.adjacentCells:
+            adjacentCell.pollution = meanPollution
         self.pollution = meanPollution
 
     def doSpiceProductionPollution(self, spiceProduced):
@@ -45,8 +45,8 @@ class Cell:
 
     def findNeighborWealth(self):
         neighborWealth = 0
-        for neighbor in self.neighbors:
-            neighborWealth += neighbor.sugar + neighbor.spice
+        for adjacentCell in self.adjacentCells:
+            neighborWealth += adjacentCell.sugar + adjacentCell.spice
         return neighborWealth
 
     def isOccupied(self):

--- a/cell.py
+++ b/cell.py
@@ -14,7 +14,7 @@ class Cell:
         self.hemisphere = "north" if self.x >= self.environment.equator else "south"
         self.season = None
         self.timestep = 0
-        self.neighbors = []
+        self.adjacentCells = set()
         self.sugarLastProduced = 0
         self.spiceLastProduced = 0
 
@@ -43,54 +43,11 @@ class Cell:
         productionPollutionFactor = self.environment.sugarProductionPollutionFactor
         self.pollution += productionPollutionFactor * sugarProduced
 
-    def findNeighborAgents(self):
-        agents = []
-        for neighbor in self.neighbors:
-            agent = neighbor.agent
-            if agent != None:
-                agents.append(agent)
-        return agents
-
-    def findNeighbors(self):
-        self.neighbors = []
-        self.neighbors.append(self.findNorthNeighbor())
-        self.neighbors.append(self.findSouthNeighbor())
-        self.neighbors.append(self.findEastNeighbor())
-        self.neighbors.append(self.findWestNeighbor())
-
     def findNeighborWealth(self):
         neighborWealth = 0
         for neighbor in self.neighbors:
             neighborWealth += neighbor.sugar + neighbor.spice
         return neighborWealth
-
-    def findEastNeighbor(self):
-        eastWrapAround = self.environment.width
-        eastIndex = self.x + 1
-        if eastIndex >= eastWrapAround:
-            eastIndex = 0
-        eastNeighbor = self.environment.findCell(eastIndex, self.y)
-        return eastNeighbor
-
-    def findNorthNeighbor(self):
-        northNeighbor = self.environment.findCell(self.x, (self.y + 1 + self.environment.height) % self.environment.height)
-        return northNeighbor
-
-    def findSouthNeighbor(self):
-        southWrapAround = 0
-        southIndex = self.y - 1
-        if southIndex < southWrapAround:
-            southIndex = self.environment.height - 1
-        southNeighbor = self.environment.findCell(self.x, southIndex)
-        return southNeighbor
-
-    def findWestNeighbor(self):
-        westWrapAround = 0
-        westIndex = self.x - 1
-        if westIndex < westWrapAround:
-            westIndex = self.environment.width - 1
-        westNeighbor = self.environment.findCell(westIndex, self.y)
-        return westNeighbor
 
     def isOccupied(self):
         return self.agent != None

--- a/config.json
+++ b/config.json
@@ -12,7 +12,7 @@
     },
     "sugarscapeOptions": {
         "__README__": "Default values for Sugarscape simulation provided here. Details can be found in the README.",
-        "agentAdjacencyMode": "von Neumann",
+        "adjacencyMode": "von Neumann",
         "agentAggressionFactor": [1, 1],
         "agentBaseInterestRate": [0.05, 0.10],
         "agentDecisionModel": "none",

--- a/config.json
+++ b/config.json
@@ -12,6 +12,7 @@
     },
     "sugarscapeOptions": {
         "__README__": "Default values for Sugarscape simulation provided here. Details can be found in the README.",
+        "agentAdjacencyMode": "von Neumann",
         "agentAggressionFactor": [1, 1],
         "agentBaseInterestRate": [0.05, 0.10],
         "agentDecisionModel": "none",

--- a/environment.py
+++ b/environment.py
@@ -131,11 +131,11 @@ class Environment:
 
     def findMooreNeighbors(self, x, y):
         cellRecords = self.findCellsInCardinalRange(x, y, 1)
-        self.grid[x][y].adjacentCells = {cellRecord["cell"] for cellRecord in cellRecords}
+        self.grid[x][y].adjacentCells = [cellRecord["cell"] for cellRecord in cellRecords]
     
     def findVonNeumannNeighbors(self, x, y):
         cellRecords = self.findCellsInRadialRange(x, y, 1)
-        self.grid[x][y].adjacentCells = {cellRecord["cell"] for cellRecord in cellRecords}
+        self.grid[x][y].adjacentCells = [cellRecord["cell"] for cellRecord in cellRecords]
 
     def resetCell(self, x, y):
         self.grid[x][y] = None

--- a/environment.py
+++ b/environment.py
@@ -130,11 +130,11 @@ class Environment:
         return cellsInRange
 
     def findMooreNeighbors(self, x, y):
-        cellRecords = self.findCellsInCardinalRange(x, y, 1)
+        cellRecords = self.findCellsInRadialRange(x, y, 1)
         self.grid[x][y].adjacentCells = [cellRecord["cell"] for cellRecord in cellRecords]
     
     def findVonNeumannNeighbors(self, x, y):
-        cellRecords = self.findCellsInRadialRange(x, y, 1)
+        cellRecords = self.findCellsInCardinalRange(x, y, 1)
         self.grid[x][y].adjacentCells = [cellRecord["cell"] for cellRecord in cellRecords]
 
     def resetCell(self, x, y):

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -34,11 +34,13 @@ class Sugarscape:
                                     "universalSugarIncomeInterval": configuration["environmentUniversalSugarIncomeInterval"],
                                     "sugarscapeSeed": configuration["seed"]}
         self.seed = configuration["seed"]
+        self.debug = configuration["debugMode"]
         self.environment = environment.Environment(configuration["environmentHeight"], configuration["environmentWidth"], self, environmentConfiguration)
         self.environmentHeight = configuration["environmentHeight"]
         self.environmentWidth = configuration["environmentWidth"]
-        self.configureEnvironment(configuration["environmentMaxSugar"], configuration["environmentMaxSpice"])
-        self.debug = configuration["debugMode"]
+        # Maintain backwards compatibility for configs without adjacencyMode
+        adjacencyMode = configuration.get("agentAdjacencyMode", None)
+        self.configureEnvironment(configuration["environmentMaxSugar"], configuration["environmentMaxSpice"], adjacencyMode)
         self.agents = []
         self.deadAgents = []
         self.diseases = []
@@ -168,7 +170,7 @@ class Sugarscape:
         if len(diseases) > 0 and ("all" in self.debug or "sugarscape" in self.debug):
             print("Could not place {0} diseases.".format(len(diseases)))
 
-    def configureEnvironment(self, maxSugar, maxSpice):
+    def configureEnvironment(self, maxSugar, maxSpice, adjacencyMode):
         height = self.environment.height
         width = self.environment.width
         for i in range(height):
@@ -193,7 +195,7 @@ class Sugarscape:
         radius = math.ceil(math.sqrt(spiceRadiusScale * (height + width)))
         self.addSpicePeak(startX1, startY1, radius, maxSpice)
         self.addSpicePeak(startX2, startY2, radius, maxSpice)
-        self.environment.findCellNeighbors()
+        self.environment.findCellNeighbors(adjacencyMode)
 
     def doTimestep(self):
         self.removeDeadAgents()

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -39,7 +39,7 @@ class Sugarscape:
         self.environmentHeight = configuration["environmentHeight"]
         self.environmentWidth = configuration["environmentWidth"]
         # Maintain backwards compatibility for configs without adjacencyMode
-        adjacencyMode = configuration.get("agentAdjacencyMode", None)
+        adjacencyMode = configuration.get("adjacencyMode", None)
         self.configureEnvironment(configuration["environmentMaxSugar"], configuration["environmentMaxSpice"], adjacencyMode)
         self.agents = []
         self.deadAgents = []


### PR DESCRIPTION
... as discussed in page 39, footnote 28 of Growing Artificial Societies.

Currently: agents have `self.mooreNeighbors` and `self.vonNeumannNeighbors`.
- `mooreNeighbors` is unused
- `vonNeumannNeighbors` is only used for `updateSocialNetwork()`
- direction info from dictionary like "north", "southwest" is never used

Currently: cells have `self.neighbors` (von Neumann). This is used for:
- `doReproduction()`
- `doDisease()`
- `doTagging()`
- `doTrading()`
- `findEmptyNeighborCells()`

I've updated the code to allow all of these use cases to use either Moore or von Neumann neighbors, all based on a new `adjacencyMode` config setting. (This could be updated to allow different adjacency modes for each use case). `adjacentNeighbors` now stores the Moore or von Neumann-adjacent agents for each agent, and `adjacentCells` stores the full Moore or von Neumann neighborhood of cells for each cell. I tried to make the names more distinguishable from `neighborhood` because they sound pretty similar.

I worked on this all at once so there's mostly just one commit. Here are a few big things I changed:
- von Neumann neighborhoods are now calculated using `findCellsInCardinalRange()` with a range of 1.
- Moore neighborhoods are now calculated using `findCellsInRadialRange()` with a range of 1.
- The directions stored in agent `self.*Neighbors` are now unused, so I've removed them altogether and replaced the data structure with a list of agents.
- Following this, the 4 `find[Direction]Neighbor()` functions are deprecated and have been removed.
- Included backwards compatibility for old config files; default adjacency mode is von Neumann.

I'll do my best to add comments on the commit where necessary. Simulations do not have any catastrophic changes and in fact appear normal, but I need to test more to make sure determinism is maintained for default von Neumann-based simulations.