### PR TITLE
Removes unintended trait correlation and unused variable

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -721,20 +721,20 @@ class Agent:
                 hashed = hashlib.md5(config.encode())
                 hashNum = int(hashed.hexdigest(), 16)
                 self.childEndowmentHashes[config] = hashNum
-            for config in pairedEndowments:
-                hashed = hashlib.md5(config.encode())
-                hashNum = int(hashed.hexdigest(), 16)
-                self.childEndowmentHashes[config] = hashNum
+            # Only one number is needed for paired endowments
+            config = pairedEndowments[0]
+            hashed = hashlib.md5(config.encode())
+            hashNum = int(hashed.hexdigest(), 16)
+            self.childEndowmentHashes[config] = hashNum
 
-        pairedEndowmentIndex = -1
         for endowment in parentEndowments:
             index = random.randrange(2)
             random.seed(self.childEndowmentHashes[endowment] + self.timestep)
             endowmentValue = parentEndowments[endowment][index]
             childEndowment[endowment] = endowmentValue
-            if pairedEndowmentIndex == -1 and endowment in pairedEndowments:
-                pairedEndowmentIndex = index
 
+        index = random.randrange(2)
+        random.seed(self.childEndowmentHashes[pairedEndowments[0]] + self.timestep)
         for endowment in pairedEndowments:
             endowmentValue = pairedEndowments[endowment][index]
             childEndowment[endowment] = endowmentValue


### PR DESCRIPTION
Current repo behavior:
- `pairedEndowmentIndex` is never used and `if... endowment in pairedEndowments` will never run because `parentEndowments` and `pairedEndowments` are mutually disjoint.
- The `pairedEndowments` loop uses `index`, which is the same as it was on the last iteration of the `parentEndowments` loop, which correlates traits that should not be correlated.
- Three separate hashes are created for `pairedEndowments`, but only one is needed because they all use the same value.

Updated behavior:
- Only one hash is created for `pairedEndowments`
- All `pairedEndowments` use the same value, which is now independent of the last iteration of the `parentEndowments` loop