### PR TITLE
Fixes eviction bug

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -555,7 +555,7 @@ class Agent:
             return agent.wealth
 
     def findAggression(self):
-        return self.aggressionFactor + self.aggressionFactorModifier
+        return max(0, self.aggressionFactor + self.aggressionFactorModifier)
 
     def findBestCell(self):
         self.findNeighborhood()

--- a/agent.py
+++ b/agent.py
@@ -576,11 +576,9 @@ class Agent:
             cell = currCell["cell"]
             travelDistance = currCell["distance"]
 
-            if cell.isOccupied() == True and aggression == 0:
-                continue
-            prey = cell.agent
             # Avoid attacking agents ineligible to attack
-            if prey != None and self.isNeighborValidPrey(prey) == False:
+            prey = cell.agent
+            if self.isNeighborValidPrey(prey) == False:
                 continue
             preyTribe = prey.tribe if prey != None else "empty"
             preySugar = prey.sugar if prey != None else 0

--- a/agent.py
+++ b/agent.py
@@ -578,7 +578,7 @@ class Agent:
 
             # Avoid attacking agents ineligible to attack
             prey = cell.agent
-            if self.isNeighborValidPrey(prey) == False:
+            if cell.isOccupied() and self.isNeighborValidPrey(prey) == False:
                 continue
             preyTribe = prey.tribe if prey != None else "empty"
             preySugar = prey.sugar if prey != None else 0

--- a/agent.py
+++ b/agent.py
@@ -1098,7 +1098,7 @@ class Agent:
             return False
 
     def isNeighborValidPrey(self, neighbor):
-        if neighbor == None or self.findAggression() == 0:
+        if neighbor == None or self.findAggression() <= 0:
             return False
         elif self.tribe != neighbor.tribe and self.wealth >= neighbor.wealth:
             return True


### PR DESCRIPTION
For #51, agents doing the evictions ("evictors") always have negative aggression due to disease modifiers. Unlike `findMovement()`, `findVision()`, `findSugarMetabolism()`, and `findSpiceMetabolism()` (other values affected by disease modifiers), `findAggression()` does not account for negative values by using a floor value of 0. Negative aggression values cause undefined behavior, resulting in evictions. Updating this function to match the others appears to entirely remove eviction bugs.