### PR TITLE
Fixes index mismatch between cell and environment causing breaks

### DIFF
--- a/cell.py
+++ b/cell.py
@@ -72,31 +72,19 @@ class Cell:
         return neighborWealth
 
     def findEastNeighbor(self):
-        eastWrapAround = self.environment.width
-        eastIndex = self.x + 1
-        if eastIndex >= eastWrapAround:
-            eastIndex = 0
-        eastNeighbor = self.environment.findCell(eastIndex, self.y)
+        eastNeighbor = self.environment.findCell((self.x + 1 + self.environment.width) % self.environment.width, self.y)
         return eastNeighbor
 
     def findNorthNeighbor(self):
-        northNeighbor = self.environment.findCell(self.x, (self.y + 1 + self.environment.height) % self.environment.height)
+        northNeighbor = self.environment.findCell(self.x, (self.y - 1 + self.environment.height) % self.environment.height)
         return northNeighbor
 
     def findSouthNeighbor(self):
-        southWrapAround = 0
-        southIndex = self.y - 1
-        if southIndex < southWrapAround:
-            southIndex = self.environment.height - 1
-        southNeighbor = self.environment.findCell(self.x, southIndex)
+        southNeighbor = self.environment.findCell(self.x, (self.y + 1 + self.environment.height) % self.environment.height)
         return southNeighbor
 
     def findWestNeighbor(self):
-        westWrapAround = 0
-        westIndex = self.x - 1
-        if westIndex < westWrapAround:
-            westIndex = self.environment.width - 1
-        westNeighbor = self.environment.findCell(westIndex, self.y)
+        westNeighbor = self.environment.findCell((self.x - 1 + self.environment.width) % self.environment.width, self.y)
         return westNeighbor
 
     def isOccupied(self):

--- a/environment.py
+++ b/environment.py
@@ -2,7 +2,7 @@ import math
 import random
 
 class Environment:
-    # Assumption: grid is always indexed by [height][width]
+    # Assumption: grid is always indexed by [width][height]
     def __init__(self, height, width, sugarscape, configuration):
         self.width = width
         self.height = height
@@ -30,11 +30,11 @@ class Environment:
         self.equator = configuration["equator"] if configuration["equator"] >= 0 else math.ceil(self.height / 2)
         self.neighborhoodMode = configuration["neighborhoodMode"]
         # Populate grid with NoneType objects
-        self.grid = [[None for j in range(width)]for i in range(height)]
+        self.grid = [[None for j in range(height)]for i in range(width)]
 
     def doCellUpdate(self):
-        for i in range(self.height):
-            for j in range(self.width):
+        for i in range(self.width):
+            for j in range(self.height):
                 cellCurrSugar = self.grid[i][j].sugar
                 cellCurrSpice = self.grid[i][j].spice
                 cellMaxSugar = self.grid[i][j].maxSugar
@@ -80,15 +80,15 @@ class Environment:
         return self.grid[x][y]
 
     def findCellNeighbors(self):
-        for i in range(self.height):
-            for j in range(self.width):
+        for i in range(self.width):
+            for j in range(self.height):
                 self.grid[i][j].findNeighbors(self.neighborhoodMode)
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []
         for i in range(1, gridRange + 1):
-            deltaNorth = (startY + i + self.height) % self.height
-            deltaSouth = (startY - i + self.height) % self.height
+            deltaNorth = (startY - i + self.height) % self.height
+            deltaSouth = (startY + i + self.height) % self.height
             deltaEast = (startX + i + self.width) % self.width
             deltaWest = (startX - i + self.width) % self.width
             cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
@@ -105,10 +105,10 @@ class Environment:
                 euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
                 # If agent can see at least part of a cell, they should be allowed to consider it
                 if euclideanDistance < gridRange + 1:
-                    deltaX = (i + self.height) % self.height
-                    reflectedX = (2 * startX - i + self.height) % self.height
-                    deltaY = (j + self.width) % self.width
-                    reflectedY = (2 * startY - j + self.width) % self.width
+                    deltaX = (i + self.width) % self.width
+                    reflectedX = (2 * startX - i + self.width) % self.width
+                    deltaY = (j + self.height) % self.height
+                    reflectedY = (2 * startY - j + self.height) % self.height
                     cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
                     cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
                     cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
@@ -120,7 +120,7 @@ class Environment:
 
     def setCell(self, cell, x, y):
         if self.grid[x][y] == None:
-            if y >= self.equator:
+            if y < self.equator:
                 cell.season = self.seasonNorth
             else:
                 cell.season = self.seasonSouth
@@ -149,8 +149,8 @@ class Environment:
 
     def __str__(self):
         string = ""
-        for i in range(0, self.height):
-            for j in range(0, self.width):
+        for i in range(self.width):
+            for j in range(self.height):
                 cell = self.grid[i][j]
                 if cell == None:
                     cell = '_'

--- a/gui.py
+++ b/gui.py
@@ -8,7 +8,7 @@ class GUI:
         self.screenWidth = screenWidth
         self.window = None
         self.canvas = None
-        self.grid = [[None for j in range(self.sugarscape.environmentWidth)]for i in range(self.sugarscape.environmentHeight)]
+        self.grid = [[None for j in range(self.sugarscape.environmentHeight)]for i in range(self.sugarscape.environmentWidth)]
         # TODO: Add a simplified way to have a bunch of colors programatically chosen during runtime
         self.colors = {"sugar": "#F2FA00", "spice": "#9B4722", "sugarAndSpice": "#CFB20E", "noSex": "#FA3232", "female": "#FA32FA", "male": "#3232FA", "pollution": "#803280",
                        "green": "#32FA32", "blue": "#3232FA", "red": "#FA3232", "pink": "#FA32FA", "yellow": "#FAFA32", "teal": "#32FAFA", "purple": "#6432FA", "orange": "#FA6432",
@@ -84,8 +84,8 @@ class GUI:
         self.canvas = canvas
 
     def configureEnvironment(self):
-        for i in range(self.sugarscape.environmentHeight):
-            for j in range(self.sugarscape.environmentWidth):
+        for i in range(self.sugarscape.environmentWidth):
+            for j in range(self.sugarscape.environmentHeight):
                 cell = self.sugarscape.environment.findCell(i, j)
                 fillColor = self.lookupFillColor(cell)
                 x1 = self.borderEdge + (0.50 * self.siteWidth) + i * self.siteWidth - (0.50 * self.siteWidth) # Upper right x coordinate
@@ -183,8 +183,8 @@ class GUI:
             return
         if self.screenHeight != self.window.winfo_height() or self.screenWidth != self.window.winfo_width():
             self.resizeInterface()
-        for i in range(self.sugarscape.environmentHeight):
-            for j in range(self.sugarscape.environmentWidth):
+        for i in range(self.sugarscape.environmentWidth):
+            for j in range(self.sugarscape.environmentHeight):
                 cell = self.sugarscape.environment.findCell(i, j)
                 fillColor = self.lookupFillColor(cell)
                 if self.grid[i][j]["color"] != fillColor:

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -72,8 +72,8 @@ class Sugarscape:
         height = self.environment.height
         width = self.environment.width
         radialDispersion = math.sqrt(max(startX, width - startX)**2 + max(startY, height - startY)**2) * (radius / width)
-        for i in range(height):
-            for j in range(width):
+        for i in range(width):
+            for j in range(height):
                 euclideanDistanceToStart = math.sqrt((startX - i)**2 + (startY - j)**2)
                 currDispersion = 1 + maxSpice * (1 - euclideanDistanceToStart / radialDispersion)
                 cellMaxCapacity = min(currDispersion, maxSpice)
@@ -86,8 +86,8 @@ class Sugarscape:
         height = self.environment.height
         width = self.environment.width
         radialDispersion = math.sqrt(max(startX, width - startX)**2 + max(startY, height - startY)**2) * (radius / width)
-        for i in range(height):
-            for j in range(width):
+        for i in range(width):
+            for j in range(height):
                 euclideanDistanceToStart = math.sqrt((startX - i)**2 + (startY - j)**2)
                 currDispersion = 1 + maxSugar * (1 - euclideanDistanceToStart / radialDispersion)
                 cellMaxCapacity = min(currDispersion, maxSugar)
@@ -182,24 +182,16 @@ class Sugarscape:
     def configureEnvironment(self, maxSugar, maxSpice, sugarPeaks, spicePeaks):
         height = self.environment.height
         width = self.environment.width
-        for i in range(height):
-            for j in range(width):
+        for i in range(width):
+            for j in range(height):
                 newCell = cell.Cell(i, j, self.environment)
                 self.environment.setCell(newCell, i, j)
 
-        startX1 = math.ceil(height * 0.7)
-        startX2 = math.ceil(height * 0.3)
-        startY1 = math.ceil(width * 0.3)
-        startY2 = math.ceil(width * 0.7)
         sugarRadiusScale = 2
         radius = math.ceil(math.sqrt(sugarRadiusScale * (height + width)))
         for peak in sugarPeaks:
             self.addSugarPeak(peak[0], peak[1], radius, maxSugar)
 
-        startX1 = math.ceil(height * 0.7)
-        startX2 = math.ceil(height * 0.3)
-        startY1 = math.ceil(width * 0.7)
-        startY2 = math.ceil(width * 0.3)
         spiceRadiusScale = 2
         radius = math.ceil(math.sqrt(spiceRadiusScale * (height + width)))
         for peak in spicePeaks:
@@ -238,8 +230,8 @@ class Sugarscape:
             self.runtimeStats["totalMetabolismCost"] += agent.sugarMetabolism + agent.spiceMetabolism
         environmentWealthCreated = 0
         environmentWealthTotal = 0
-        for i in range(self.environment.height):
-            for j in range(self.environment.width):
+        for i in range(self.environment.width):
+            for j in range(self.environment.height):
                 environmentWealthCreated += self.environment.grid[i][j].sugarLastProduced + self.environment.grid[i][j].spiceLastProduced
                 environmentWealthTotal += self.environment.grid[i][j].sugar + self.environment.grid[i][j].spice
         self.runtimeStats["environmentWealthCreated"] = environmentWealthCreated
@@ -686,8 +678,8 @@ class Sugarscape:
 
         environmentWealthCreated = 0
         environmentWealthTotal = 0
-        for i in range(self.environment.height):
-            for j in range(self.environment.width):
+        for i in range(self.environment.width):
+            for j in range(self.environment.height):
                 environmentWealthCreated += self.environment.grid[i][j].sugarLastProduced + self.environment.grid[i][j].spiceLastProduced
                 environmentWealthTotal += self.environment.grid[i][j].sugar + self.environment.grid[i][j].spice
                 if self.timestep == 1:


### PR DESCRIPTION
Current repo:
- `Cells` are indexed by `(x, y)` or `(width, height)`.
- `Environment` is indexed by `[height][width]`. See line 5 of `environment.py`.
- Due to this mismatch, any environment size that is not square breaks.
- "North" is considered to be in the positive y direction (downwards on GUI). 

This PR:
- Having to choose one of the two coordinate systems, sticking with `Cell` `(x, y)` makes more sense.
- `Environment` is now indexed by `[width][height]` (required changes to multiple files).
- "North" is now in the negative y direction (upwards on GUI, which is more accurate). Affects season placement and neighbor naming.
- Standardizes `find*Neighbor()` functions to look the same as `findNorthNeighbor()`.
- Removes unused variables in sugar and spice peak generation.