### PR TITLE
Modifies disease behavior for upcoming network visualizations feature

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -151,7 +151,7 @@ class Agent:
         elif neighbor.marginalRateOfSubstitution == self.marginalRateOfSubstitution:
             return False
 
-    def catchDisease(self, disease):
+    def catchDisease(self, disease, infector=None):
         diseaseID = disease.ID
         for currDisease in self.diseases:
             currDiseaseID = currDisease["disease"].ID
@@ -166,9 +166,10 @@ class Agent:
         startIndex = diseaseInImmuneSystem["start"]
         endIndex = diseaseInImmuneSystem["end"]
         caughtDisease = {"disease": disease, "startIndex": startIndex, "endIndex": endIndex}
+        if infector != None:
+            caughtDisease["infector"] = infector
         self.diseases.append(caughtDisease)
         self.updateDiseaseEffects(disease)
-        disease.agent = self
 
     def collectResourcesAtCell(self):
         sugarCollected = self.cell.sugar
@@ -223,6 +224,7 @@ class Agent:
         self.neighborhood = []
         self.vonNeumannNeighbors = {}
         self.mooreNeighbors = {}
+        self.diseases = []
 
     def doDisease(self):
         diseases = self.diseases
@@ -253,7 +255,7 @@ class Agent:
                 neighbors.append(neighbor)
         random.shuffle(neighbors)
         for neighbor in neighbors:
-            self.spreadDisease(neighbor, self.diseases[random.randrange(diseaseCount)]["disease"])
+            neighbor.catchDisease(self.diseases[random.randrange(diseaseCount)]["disease"], self)
 
     def doInheritance(self):
         if self.inheritancePolicy == "none":
@@ -1215,10 +1217,6 @@ class Agent:
 
     def spawnChild(self, childID, birthday, cell, configuration):
         return Agent(childID, birthday, cell, configuration)
-
-    def spreadDisease(self, agent, disease):
-        sugarscape = self.cell.environment.sugarscape
-        sugarscape.addDisease(disease, agent)
 
     def sortCellsByWealth(self, cells):
         # Insertion sort of cells by wealth in descending order with range as a tiebreaker

--- a/disease.py
+++ b/disease.py
@@ -12,7 +12,6 @@ class Disease:
         self.aggressionPenalty = configuration["aggressionPenalty"]
         self.tags = configuration["tags"]
         self.configuration = configuration
-        self.agent = None
 
     def __str__(self):
         return "{0}".format(self.ID)

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -62,12 +62,6 @@ class Sugarscape:
     def addAgent(self, agent):
         self.agents.append(agent)
 
-    def addDisease(self, oldDisease, agent):
-        diseaseID = oldDisease.ID
-        diseaseConfig = oldDisease.configuration
-        newDisease = disease.Disease(diseaseID, diseaseConfig)
-        agent.catchDisease(newDisease)
-
     def addSpicePeak(self, startX, startY, radius, maxSpice):
         height = self.environment.height
         width = self.environment.width


### PR DESCRIPTION
- Adds disease infector information in `agent.diseases`, which will be necessary for drawing lines between infected agents and who they caught their diseases from for the disease network.
- Modifies behavior of `Disease` objects to share between multiple agents rather than creating a new copy for each agent. `disease.agent` was never used and doesn't make sense following this change, so I removed it. We can readd a list of diseased agents for each `Disease` object if need be, but there's no reason to yet.
- Simplifies the callstack from `catchDisease`, `spreadDisease`, `addDisease` down to just `catchDisease`. The naming was confusing and the functions unnecessarily tracked across files when all functionality can be contained in `agent.py`.