### PR TITLE
Modifies example configs' movement to 1000 to match range distribution in book

### DIFF
--- a/examples/agent_replacement.json
+++ b/examples/agent_replacement.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 250,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/agent_replacement.json
+++ b/examples/agent_replacement.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 250,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/blank.json
+++ b/examples/blank.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/blank.json
+++ b/examples/blank.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/combat_limited.json
+++ b/examples/combat_limited.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 400,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/combat_limited.json
+++ b/examples/combat_limited.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 400,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/combat_unlimited.json
+++ b/examples/combat_unlimited.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/combat_unlimited.json
+++ b/examples/combat_unlimited.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/constant_growback.json
+++ b/examples/constant_growback.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/constant_growback.json
+++ b/examples/constant_growback.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/cultural_tagging.json
+++ b/examples/cultural_tagging.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/cultural_tagging.json
+++ b/examples/cultural_tagging.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/disease_basic.json
+++ b/examples/disease_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/disease_basic.json
+++ b/examples/disease_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/foresight_basic.json
+++ b/examples/foresight_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/foresight_basic.json
+++ b/examples/foresight_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/immediate_growback.json
+++ b/examples/immediate_growback.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [-1, -1],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/immediate_growback.json
+++ b/examples/immediate_growback.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [-1, -1],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/lending_basic.json
+++ b/examples/lending_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/lending_basic.json
+++ b/examples/lending_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/pollution_formation.json
+++ b/examples/pollution_formation.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/pollution_formation.json
+++ b/examples/pollution_formation.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/reproduction_basic.json
+++ b/examples/reproduction_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/reproduction_basic.json
+++ b/examples/reproduction_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/reproduction_inheritance.json
+++ b/examples/reproduction_inheritance.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/reproduction_inheritance.json
+++ b/examples/reproduction_inheritance.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/reproduction_limited.json
+++ b/examples/reproduction_limited.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/reproduction_limited.json
+++ b/examples/reproduction_limited.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/seasonal_migration.json
+++ b/examples/seasonal_migration.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [-1, -1],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/seasonal_migration.json
+++ b/examples/seasonal_migration.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [-1, -1],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [0, 0],
     "agentStartingSpice": [0, 0],

--- a/examples/spice_growback.json
+++ b/examples/spice_growback.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/spice_growback.json
+++ b/examples/spice_growback.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/trade_basic.json
+++ b/examples/trade_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/trade_basic.json
+++ b/examples/trade_basic.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/trade_pollution.json
+++ b/examples/trade_pollution.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/trade_pollution.json
+++ b/examples/trade_pollution.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 0,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/trade_replacement.json
+++ b/examples/trade_replacement.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [1, 6],
+    "agentMovement": [9999, 9999],
     "agentReplacements": 400,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],

--- a/examples/trade_replacement.json
+++ b/examples/trade_replacement.json
@@ -15,7 +15,7 @@
     "agentMaleToFemaleRatio": 1,
     "agentMaxAge": [60, 100],
     "agentMaxFriends": [0, 0],
-    "agentMovement": [9999, 9999],
+    "agentMovement": [1000, 1000],
     "agentReplacements": 400,
     "agentSpiceMetabolism": [1, 4],
     "agentStartingSpice": [10, 40],


### PR DESCRIPTION
Current repo:
- An agent's functional range is the min of their vision and movement.
- In practice, if both are random variables from 1 to 10, the range distribution will be slanted with range 1 having a 19% chance and range 10 having only a 1% chance.
- This does not follow the book. Because they use one variable for both, book agents have a uniform range distribution with every integer in the interval being equally likely.

Changes:
- Updated `README`, "true default" settings in `sugarscape.py`, and `config.json` to use single-variable range by default. Movement is set to 9999 and vision is used as the deciding variable.
- I chose vision rather than movement because agents having comically large vision might imply that they have more information than they actually do. It's more intuitive for them to have limited vision and the ability to move wherever they want inside of that vision.
- Removed movement from all example configs so that they will correctly use single-variable range distributions. Removing all default settings from example configs for clarity will be a separate PR.