### PR TITLE
Adds variable quadrant sizing

### DIFF
--- a/README
+++ b/README
@@ -319,6 +319,10 @@ environmentPollutionDiffusionDelay: int
     Set the delay interval in timesteps when pollution is diffused across the environment.
     Default: 0
 
+environmentQuadrantSizeFactor: float
+    Set the proportion of each corner of the screen taken up by the agents' starting quadrants.
+    Default: 1
+
 environmentSeasonalGrowbackDelay: int
     Set the delay interval in timesteps when resources are regrown when cell is in a dry season.
     Default: 0

--- a/config.json
+++ b/config.json
@@ -60,6 +60,7 @@
         "environmentMaxSugar": 4,
         "environmentMaxTribes": 3,
         "environmentPollutionDiffusionDelay": 0,
+        "environmentQuadrantSizeFactor": 1,
         "environmentSeasonalGrowbackDelay": 0,
         "environmentSeasonInterval": 0,
         "environmentSpiceConsumptionPollutionFactor": 0,

--- a/examples/combat_limited.json
+++ b/examples/combat_limited.json
@@ -38,6 +38,7 @@
     "environmentMaxSugar": 4,
     "environmentMaxTribes": 2,
     "environmentPollutionDiffusionDelay": 0,
+    "environmentQuadrantSizeFactor": 0.8,
     "environmentSeasonalGrowbackDelay": 0,
     "environmentSeasonInterval": 0,
     "environmentSpiceConsumptionPollutionFactor": 0,

--- a/examples/combat_unlimited.json
+++ b/examples/combat_unlimited.json
@@ -38,6 +38,7 @@
     "environmentMaxSugar": 4,
     "environmentMaxTribes": 2,
     "environmentPollutionDiffusionDelay": 0,
+    "environmentQuadrantSizeFactor": 0.8,
     "environmentSeasonalGrowbackDelay": 0,
     "environmentSeasonInterval": 0,
     "environmentSpiceConsumptionPollutionFactor": 0,

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -38,6 +38,7 @@ class Sugarscape:
         self.environment = environment.Environment(configuration["environmentHeight"], configuration["environmentWidth"], self, environmentConfiguration)
         self.environmentHeight = configuration["environmentHeight"]
         self.environmentWidth = configuration["environmentWidth"]
+        self.activeQuadrants = self.findActiveQuadrants()
         self.configureEnvironment(configuration["environmentMaxSugar"], configuration["environmentMaxSpice"], configuration["environmentSugarPeaks"], configuration["environmentSpicePeaks"])
         self.debug = configuration["debugMode"]
         self.agents = []
@@ -94,8 +95,7 @@ class Sugarscape:
         if self.environment == None:
             return
 
-        activeQuadrants = self.findActiveQuadrants()
-        activeCells = [cell for quadrant in activeQuadrants for cell in quadrant]
+        activeCells = [cell for quadrant in self.activeQuadrants for cell in quadrant]
         totalCells = len(activeCells)
         if totalCells == 0:
             return

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -95,10 +95,10 @@ class Sugarscape:
             return
 
         activeCells = self.findActiveQuadrants()
-        if len(activeCells) == 0:
+        totalCells = len(activeCells)
+        if totalCells == 0:
             return
 
-        totalCells = len(activeCells)
         if len(self.agents) + numAgents > totalCells:
             if "all" in self.debug or "sugarscape" in self.debug:
                 print("Could not allocate {0} agents. Allocating maximum of {1}.".format(numAgents, totalCells))
@@ -254,8 +254,8 @@ class Sugarscape:
     def findActiveQuadrants(self):
         quadrants = self.configuration["agentStartingQuadrants"]
         cellRange = []
-        halfWidth = math.floor(self.environmentWidth / 2)
-        halfHeight = math.floor(self.environmentHeight / 2)
+        halfWidth = math.floor(self.environmentWidth / 2 * self.configuration["environmentQuadrantSizeFactor"])
+        halfHeight = math.floor(self.environmentHeight / 2 * self.configuration["environmentQuadrantSizeFactor"])
         # Quadrant I at origin in top left corner, other quadrants in clockwise order
         if 1 in quadrants:
             quadRange = [[(i, j) for j in range(halfHeight)] for i in range(halfWidth)]
@@ -894,8 +894,12 @@ def printHelp():
     exit(0)
 
 def verifyConfiguration(configuration):
+    if len(configuration["agentStartingQuadrants"]) == 0:
+        configuration["agentStartingQuadrants"] = [1, 2, 3, 4]
+
     # Ensure starting agents are not larger than available cells
     totalCells = configuration["environmentHeight"] * configuration["environmentWidth"]
+    totalCells = totalCells * (configuration["environmentQuadrantSizeFactor"] ** 2) * len(configuration["agentStartingQuadrants"]) / 4
     if configuration["startingAgents"] > totalCells:
         if "all" in configuration["debugMode"] or "sugarscape" in configuration["debugMode"]:
             print("Could not allocate {0} agents. Allocating maximum of {1}.".format(configuration["startingAgents"], totalCells))
@@ -911,9 +915,6 @@ def verifyConfiguration(configuration):
         configuration["environmentMaxTribes"] = configuration["agentTagStringLength"]
     if configuration["environmentMaxTribes"] > 11:
         configuration["environmentMaxTribes"] = 11
-
-    if len(configuration["agentStartingQuadrants"]) == 0:
-        configuration["agentStartingQuadrants"] = [1, 2, 3, 4]
 
     # Set timesteps to (seemingly) unlimited runtime
     if configuration["timesteps"] < 0:
@@ -1003,6 +1004,7 @@ if __name__ == "__main__":
                      "environmentMaxSugar": 4,
                      "environmentMaxTribes": 0,
                      "environmentPollutionDiffusionDelay": 0,
+                     "environmentQuadrantSizeFactor": 1,
                      "environmentSeasonalGrowbackDelay": 0,
                      "environmentSeasonInterval": 0,
                      "environmentSpiceConsumptionPollutionFactor": 0,

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -94,7 +94,8 @@ class Sugarscape:
         if self.environment == None:
             return
 
-        activeCells = self.findActiveQuadrants()
+        activeQuadrants = self.findActiveQuadrants()
+        activeCells = [cell for quadrant in activeQuadrants for cell in quadrant]
         totalCells = len(activeCells)
         if totalCells == 0:
             return
@@ -106,11 +107,10 @@ class Sugarscape:
 
         # Ensure agent endowments are randomized across initial agent count to make replacements follow same distributions
         agentEndowments = self.randomizeAgentEndowments(numAgents)
-        randCoords = activeCells
-        random.shuffle(randCoords)
+        random.shuffle(activeCells)
 
         for i in range(numAgents):
-            randCoord = randCoords.pop()
+            randCoord = activeCells.pop()
             randCellX = randCoord[0]
             randCellY = randCoord[1]
             c = self.environment.findCell(randCellX, randCellY)
@@ -254,29 +254,21 @@ class Sugarscape:
     def findActiveQuadrants(self):
         quadrants = self.configuration["agentStartingQuadrants"]
         cellRange = []
-        halfWidth = math.floor(self.environmentWidth / 2 * self.configuration["environmentQuadrantSizeFactor"])
-        halfHeight = math.floor(self.environmentHeight / 2 * self.configuration["environmentQuadrantSizeFactor"])
+        quadrantWidth = math.floor(self.environmentWidth / 2 * self.configuration["environmentQuadrantSizeFactor"])
+        quadrantHeight = math.floor(self.environmentHeight / 2 * self.configuration["environmentQuadrantSizeFactor"])
         # Quadrant I at origin in top left corner, other quadrants in clockwise order
         if 1 in quadrants:
-            quadRange = [[(i, j) for j in range(halfHeight)] for i in range(halfWidth)]
-            for i in range(halfWidth):
-                for j in range(halfHeight):
-                    cellRange.append([i, j])
+            quadrantOne = [(i, j) for j in range(quadrantHeight) for i in range(quadrantWidth)]
+            cellRange.append(quadrantOne)
         if 2 in quadrants:
-            quadRange = [[(i, j) for j in range(halfHeight)] for i in range(halfWidth, self.environmentWidth)]
-            for i in range(halfWidth, self.environmentWidth):
-                for j in range(halfHeight):
-                    cellRange.append([i, j])
+            quadrantTwo = [(i, j) for j in range(quadrantHeight) for i in range(self.environmentWidth - quadrantWidth, self.environmentWidth)]
+            cellRange.append(quadrantTwo)
         if 3 in quadrants:
-            quadRange = [[(i, j) for j in range(halfHeight, self.environmentHeight)] for i in range(halfWidth, self.environmentWidth)]
-            for i in range(halfWidth, self.environmentWidth):
-                for j in range(halfHeight, self.environmentHeight):
-                    cellRange.append([i, j])
+            quadrantThree = [(i, j) for j in range(self.environmentHeight - quadrantHeight, self.environmentHeight) for i in range(self.environmentWidth - quadrantWidth, self.environmentWidth)]
+            cellRange.append(quadrantThree)
         if 4 in quadrants:
-            quadRange = [[(i, j) for j in range(halfHeight, self.environmentHeight)] for i in range(halfWidth)]
-            for i in range(halfWidth):
-                for j in range(halfHeight, self.environmentHeight):
-                    cellRange.append([i, j])
+            quadrantFour = [(i, j) for j in range(self.environmentHeight - quadrantHeight, self.environmentHeight) for i in range(quadrantWidth)]
+            cellRange.append(quadrantFour)
         return cellRange
 
     def generateAgentID(self):

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -889,6 +889,11 @@ def verifyConfiguration(configuration):
     if len(configuration["agentStartingQuadrants"]) == 0:
         configuration["agentStartingQuadrants"] = [1, 2, 3, 4]
 
+    if configuration["environmentQuadrantSizeFactor"] > 1:
+        configuration["environmentQuadrantSizeFactor"] = 1
+    elif configuration["environmentQuadrantSizeFactor"] < 0:
+        configuration["environmentQuadrantSizeFactor"] = 1
+
     # Ensure starting agents are not larger than available cells
     totalCells = configuration["environmentHeight"] * configuration["environmentWidth"]
     totalCells = totalCells * (configuration["environmentQuadrantSizeFactor"] ** 2) * len(configuration["agentStartingQuadrants"]) / 4


### PR DESCRIPTION
- New config setting: `"environmentQuadrantSizeFactor"` between 0 and 1.
- The default is 1, which means the quadrants agents start in each take up exactly one quarter of the environment.
- The combat examples from the book use 20x20 quadrants = a quadrant size factor of 0.8, so their configs have been modified to account for this.
- `findActiveQuadrants()` was wasting runtime being called every timestep, so it is now only called once at the beginning of the simulation.
- The list returned by `findActiveQuadrants()` is now a list of lists with each sublist being a quadrant. This will be very useful for adding specific tribes to quadrants, which can be added after this PR goes through.