### PR TITLE
Adds config option to disable wraparound

### DIFF
--- a/README
+++ b/README
@@ -374,6 +374,10 @@ environmentWidth: int
     Set the width in cells of the Sugarscape environment.
     Default: 50
 
+environmentWraparound: bool
+    Set whether the environment is a torus (wraparound) or a plane (no wraparound).
+    Default: true
+
 headlessMode: bool
     Set whether the GUI is enabled.
     Default: false

--- a/agent.py
+++ b/agent.py
@@ -51,6 +51,7 @@ class Agent:
         self.cellsInRange = []
         self.lastMoved = -1
         self.neighborhood = []
+        self.socialNeighbors = []
         self.socialNetwork = {"father": None, "mother": None, "children": [], "friends": [], "creditors": [], "debtors": []}
         self.diseases = []
         self.fertile = False
@@ -220,6 +221,7 @@ class Agent:
 
         # Keep only debtors and children in social network to handle outstanding loans
         self.socialNetwork = {"debtors": self.socialNetwork["debtors"], "children": self.socialNetwork["children"]}
+        self.socialNeighbors = []
         self.neighborhood = []
         self.diseases = []
 
@@ -431,7 +433,7 @@ class Agent:
             self.lastSpice = self.spice
             self.lastMoved = self.timestep
             self.moveToBestCell()
-            self.updateSocialNetwork()
+            self.updateNeighbors()
             self.collectResourcesAtCell()
             self.doUniversalIncome()
             self.doMetabolism()
@@ -1297,10 +1299,16 @@ class Agent:
         self.sugarMeanIncome = (alpha * sugarIncome) + ((1 - alpha) * self.sugarMeanIncome)
         self.spiceMeanIncome = (alpha * spiceIncome) + ((1 - alpha) * self.spiceMeanIncome)
 
-    def updateSocialNetwork(self):
-        neighborCells = self.cell.neighbors
-        for neighborCell in neighborCells.values():
+    def updateNeighbors(self):
+        self.socialNeighbors = []
+        for neighborCell in self.cell.neighbors.values():
             neighbor = neighborCell.agent
+            if neighbor != None:
+                self.socialNeighbors.append(neighbor)
+        self.updateSocialNetwork()
+
+    def updateSocialNetwork(self):
+        for neighbor in self.socialNeighbors:
             if neighbor == None:
                 continue
             neighborID = neighbor.ID

--- a/agent.py
+++ b/agent.py
@@ -51,8 +51,6 @@ class Agent:
         self.cellsInRange = []
         self.lastMoved = -1
         self.neighborhood = []
-        self.vonNeumannNeighbors = {"north": None, "south": None, "east": None, "west": None}
-        self.mooreNeighbors = {"north": None, "northeast": None, "northwest": None, "south": None, "southeast": None, "southwest": None, "east": None, "west": None}
         self.socialNetwork = {"father": None, "mother": None, "children": [], "friends": [], "creditors": [], "debtors": []}
         self.diseases = []
         self.fertile = False
@@ -223,8 +221,6 @@ class Agent:
         # Keep only debtors and children in social network to handle outstanding loans
         self.socialNetwork = {"debtors": self.socialNetwork["debtors"], "children": self.socialNetwork["children"]}
         self.neighborhood = []
-        self.vonNeumannNeighbors = {}
-        self.mooreNeighbors = {}
         self.diseases = []
 
     def doDisease(self):
@@ -248,7 +244,7 @@ class Agent:
         diseaseCount = len(self.diseases)
         if diseaseCount == 0:
             return
-        neighborCells = self.cell.neighbors
+        neighborCells = self.cell.neighbors.values()
         neighbors = []
         for neighborCell in neighborCells:
             neighbor = neighborCell.agent
@@ -373,7 +369,7 @@ class Agent:
         # Agent marked for removal or not interested in reproduction should not reproduce
         if self.isAlive() == False or self.isFertile() == False:
             return
-        neighborCells = self.cell.neighbors
+        neighborCells = list(self.cell.neighbors.values())
         random.shuffle(neighborCells)
         emptyCells = self.findEmptyNeighborCells()
         for neighborCell in neighborCells:
@@ -418,7 +414,7 @@ class Agent:
     def doTagging(self):
         if self.tags == None or self.isAlive() == False:
             return
-        neighborCells = self.cell.neighbors
+        neighborCells = list(self.cell.neighbors.values())
         random.shuffle(neighborCells)
         for neighborCell in neighborCells:
             neighbor = neighborCell.agent
@@ -435,7 +431,7 @@ class Agent:
             self.lastSpice = self.spice
             self.lastMoved = self.timestep
             self.moveToBestCell()
-            self.updateNeighbors()
+            self.updateSocialNetwork()
             self.collectResourcesAtCell()
             self.doUniversalIncome()
             self.doMetabolism()
@@ -469,7 +465,7 @@ class Agent:
         self.sugarPrice = 0
         self.spicePrice = 0
         self.findMarginalRateOfSubstitution()
-        neighborCells = self.cell.neighbors
+        neighborCells = self.cell.neighbors.values()
         traders = []
         for neighborCell in neighborCells:
             neighbor = neighborCell.agent
@@ -817,7 +813,7 @@ class Agent:
 
     def findEmptyNeighborCells(self):
         emptyCells = []
-        neighborCells = self.cell.neighbors
+        neighborCells = self.cell.neighbors.values()
         for neighborCell in neighborCells:
             if neighborCell.agent == None:
                 emptyCells.append(neighborCell)
@@ -1289,23 +1285,6 @@ class Agent:
             if timeRemaining == 0:
                 self.payDebt(creditor)
 
-    def updateMooreNeighbors(self):
-        # Necessitates finding von Neumann neighbors before invoking this method
-        for direction, neighbor in self.vonNeumannNeighbors.items():
-            self.mooreNeighbors[direction] = neighbor
-        north = self.mooreNeighbors["north"]
-        south = self.mooreNeighbors["south"]
-        east = self.mooreNeighbors["east"]
-        west = self.mooreNeighbors["west"]
-        self.mooreNeighbors["northeast"] = north.cell.findEastNeighbor().agent if north != None else None
-        self.mooreNeighbors["northeast"] = east.cell.findNorthNeighbor().agent if east != None and self.mooreNeighbors["northeast"] == None else None
-        self.mooreNeighbors["northwest"] = north.cell.findWestNeighbor().agent if north != None else None
-        self.mooreNeighbors["northwest"] = west.cell.findNorthNeighbor().agent if west != None and self.mooreNeighbors["northwest"] == None else None
-        self.mooreNeighbors["southeast"] = south.cell.findEastNeighbor().agent if south != None else None
-        self.mooreNeighbors["southeast"] = east.cell.findSouthNeighbor().agent if east != None and self.mooreNeighbors["southeast"] == None else None
-        self.mooreNeighbors["southwest"] = south.cell.findWestNeighbor().agent if south != None else None
-        self.mooreNeighbors["southwest"] = west.cell.findSouthNeighbor().agent if west != None and self.mooreNeighbors["southwest"] == None else None
-
     def updateMarginalRateOfSubstitutionForAgent(self, agent):
         agentID = agent.ID
         if agentID not in self.socialNetwork:
@@ -1318,14 +1297,10 @@ class Agent:
         self.sugarMeanIncome = (alpha * sugarIncome) + ((1 - alpha) * self.sugarMeanIncome)
         self.spiceMeanIncome = (alpha * spiceIncome) + ((1 - alpha) * self.spiceMeanIncome)
 
-    def updateNeighbors(self):
-        self.updateVonNeumannNeighbors()
-        self.updateMooreNeighbors()
-        self.updateSocialNetwork()
-
     def updateSocialNetwork(self):
-        neighborhood = self.vonNeumannNeighbors if self.neighborhoodMode == "vonNeumann" else self.mooreNeighbors
-        for direction, neighbor in neighborhood.items():
+        neighborCells = self.cell.neighbors
+        for neighborCell in neighborCells.values():
+            neighbor = neighborCell.agent
             if neighbor == None:
                 continue
             neighborID = neighbor.ID
@@ -1357,12 +1332,6 @@ class Agent:
         else:
             self.socialNetwork[agentID]["timesVisited"] += 1
             self.socialNetwork[agentID]["lastSeen"] = timestep
-
-    def updateVonNeumannNeighbors(self):
-        self.vonNeumannNeighbors["north"] = self.cell.findNorthNeighbor().agent
-        self.vonNeumannNeighbors["south"] = self.cell.findSouthNeighbor().agent
-        self.vonNeumannNeighbors["east"] = self.cell.findEastNeighbor().agent
-        self.vonNeumannNeighbors["west"] = self.cell.findWestNeighbor().agent
 
     def updateHappiness(self):
         if self.isAlive() == False:

--- a/agent.py
+++ b/agent.py
@@ -51,7 +51,7 @@ class Agent:
         self.cellsInRange = []
         self.lastMoved = -1
         self.neighborhood = []
-        self.socialNeighbors = []
+        self.neighbors = []
         self.socialNetwork = {"father": None, "mother": None, "children": [], "friends": [], "creditors": [], "debtors": []}
         self.diseases = []
         self.fertile = False
@@ -221,7 +221,7 @@ class Agent:
 
         # Keep only debtors and children in social network to handle outstanding loans
         self.socialNetwork = {"debtors": self.socialNetwork["debtors"], "children": self.socialNetwork["children"]}
-        self.socialNeighbors = []
+        self.neighbors = []
         self.neighborhood = []
         self.diseases = []
 
@@ -1300,15 +1300,11 @@ class Agent:
         self.spiceMeanIncome = (alpha * spiceIncome) + ((1 - alpha) * self.spiceMeanIncome)
 
     def updateNeighbors(self):
-        self.socialNeighbors = []
-        for neighborCell in self.cell.neighbors.values():
-            neighbor = neighborCell.agent
-            if neighbor != None:
-                self.socialNeighbors.append(neighbor)
+        self.neighbors = [neighborCell.agent for neighborCell in self.cell.neighbors.values() if neighborCell.agent != None]
         self.updateSocialNetwork()
 
     def updateSocialNetwork(self):
-        for neighbor in self.socialNeighbors:
+        for neighbor in self.neighbors:
             if neighbor == None:
                 continue
             neighborID = neighbor.ID

--- a/cell.py
+++ b/cell.py
@@ -14,7 +14,7 @@ class Cell:
         self.hemisphere = "north" if self.x >= self.environment.equator else "south"
         self.season = None
         self.timestep = 0
-        self.neighbors = []
+        self.neighbors = {}
         self.sugarLastProduced = 0
         self.spiceLastProduced = 0
 
@@ -28,10 +28,10 @@ class Cell:
 
     def doPollutionDiffusion(self):
         meanPollution = self.pollution
-        for neighbor in self.neighbors:
+        for neighbor in self.neighbors.values():
             meanPollution += neighbor.pollution
         meanPollution = meanPollution / (len(self.neighbors) + 1)
-        for neighbor in self.neighbors:
+        for neighbor in self.neighbors.values():
             neighbor.pollution = meanPollution
         self.pollution = meanPollution
 
@@ -45,30 +45,47 @@ class Cell:
 
     def findNeighborAgents(self):
         agents = []
-        for neighbor in self.neighbors:
+        for neighbor in self.neighbors.values():
             agent = neighbor.agent
             if agent != None:
                 agents.append(agent)
         return agents
 
     def findNeighbors(self, mode):
-        self.neighbors = []
+        self.neighbors = {}
+
         north = self.findNorthNeighbor()
         south = self.findSouthNeighbor()
-        self.neighbors.append(north)
-        self.neighbors.append(south)
-        self.neighbors.append(self.findEastNeighbor())
-        self.neighbors.append(self.findWestNeighbor())
+        east = self.findEastNeighbor()
+        west = self.findWestNeighbor()
+        if north is not None:
+            self.neighbors["north"] = north
+        if south is not None:
+            self.neighbors["south"] = south
+        if east is not None:
+            self.neighbors["east"] = east
+        if west is not None:
+            self.neighbors["west"] = west
+
         if mode == "moore":
-            self.neighbors.append(north.findEastNeighbor())
-            self.neighbors.append(north.findWestNeighbor())
-            self.neighbors.append(south.findEastNeighbor())
-            self.neighbors.append(south.findWestNeighbor())
+            northeast = north.findEastNeighbor() if north is not None else None
+            northwest = north.findWestNeighbor() if north is not None else None
+            southeast = south.findEastNeighbor() if south is not None else None
+            southwest = south.findWestNeighbor() if south is not None else None
+            if northeast is not None:
+                self.neighbors["northeast"] = northeast
+            if northwest is not None:
+                self.neighbors["northwest"] = northwest
+            if southeast is not None:
+                self.neighbors["southeast"] = southeast
+            if southwest is not None:
+                self.neighbors["southwest"] = southwest
 
     def findNeighborWealth(self):
         neighborWealth = 0
-        for neighbor in self.neighbors:
-            neighborWealth += neighbor.sugar + neighbor.spice
+        for neighbor in self.neighbors.values():
+            if neighbor != None:
+                neighborWealth += neighbor.sugar + neighbor.spice
         return neighborWealth
 
     def findEastNeighbor(self):

--- a/cell.py
+++ b/cell.py
@@ -72,18 +72,26 @@ class Cell:
         return neighborWealth
 
     def findEastNeighbor(self):
+        if self.environment.wraparound == False and self.x + 1 > self.environment.width - 1:
+            return None
         eastNeighbor = self.environment.findCell((self.x + 1 + self.environment.width) % self.environment.width, self.y)
         return eastNeighbor
 
     def findNorthNeighbor(self):
+        if self.environment.wraparound == False and self.y - 1 < 0:
+            return None
         northNeighbor = self.environment.findCell(self.x, (self.y - 1 + self.environment.height) % self.environment.height)
         return northNeighbor
 
     def findSouthNeighbor(self):
+        if self.environment.wraparound == False and self.y + 1 < self.environment.height - 1:
+            return None
         southNeighbor = self.environment.findCell(self.x, (self.y + 1 + self.environment.height) % self.environment.height)
         return southNeighbor
 
     def findWestNeighbor(self):
+        if self.environment.wraparound == False and self.x - 1 < 0:
+            return None
         westNeighbor = self.environment.findCell((self.x - 1 + self.environment.width) % self.environment.width, self.y)
         return westNeighbor
 

--- a/config.json
+++ b/config.json
@@ -73,6 +73,7 @@
         "environmentUniversalSpiceIncomeInterval": 0,
         "environmentUniversalSugarIncomeInterval": 0,
         "environmentWidth": 50,
+        "environmentWraparound": true,
         "headlessMode": false,
         "interfaceHeight": 1000,
         "interfaceWidth": 900,

--- a/environment.py
+++ b/environment.py
@@ -114,21 +114,29 @@ class Environment:
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
-        cellsInRange = self.findCellsInCardinalRange(startX, startY, gridRange)
-        # Iterate through the upper left quadrant of the circle's bounding box
-        for i in range(startX - gridRange, startX):
-            for j in range(startY - gridRange, startY):
-                euclideanDistance = math.sqrt(pow((i - startX), 2) + pow((j - startY), 2))
-                # If agent can see at least part of a cell, they should be allowed to consider it
-                if euclideanDistance < gridRange + 1:
-                    deltaX = (i + self.width) % self.width
-                    reflectedX = (2 * startX - i + self.width) % self.width
-                    deltaY = (j + self.height) % self.height
-                    reflectedY = (2 * startY - j + self.height) % self.height
-                    cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
-                    cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
-                    cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
-                    cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})
+        if self.wraparound == True:
+            cellsInRange = self.findCellsInCardinalRange(startX, startY, gridRange)
+            # Iterate through the upper left quadrant of the circle's bounding box
+            for deltaX in range(startX - gridRange, startX):
+                for deltaY in range(startY - gridRange, startY):
+                    euclideanDistance = math.sqrt(pow((deltaX - startX), 2) + pow((deltaY - startY), 2))
+                    # If agent can see at least part of a cell, they should be allowed to consider it
+                    if euclideanDistance < gridRange + 1:
+                        reflectedX = (2 * startX - deltaX + self.width) % self.width
+                        reflectedY = (2 * startY - deltaY + self.height) % self.height
+                        cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
+                        cellsInRange.append({"cell": self.grid[deltaX][reflectedY], "distance": euclideanDistance})
+                        cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
+                        cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})        
+        else:
+            cellsInRange = []
+            # Iterate through the bounding box of the circle
+            for deltaX in range(max(0, startX - gridRange), min(self.width, startX + gridRange + 1)):
+                for deltaY in range(max(0, startY - gridRange), min(self.height, startY + gridRange + 1)):
+                    # If agent can see at least part of a cell, they should be allowed to consider it
+                    euclideanDistance = math.sqrt((deltaX - startX)**2 + (deltaY - startY)**2)
+                    if euclideanDistance < gridRange + 1 and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
+                        cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
         return cellsInRange
 
     def resetCell(self, x, y):

--- a/environment.py
+++ b/environment.py
@@ -29,6 +29,7 @@ class Environment:
         self.universalSugarIncomeInterval = configuration["universalSugarIncomeInterval"]
         self.equator = configuration["equator"] if configuration["equator"] >= 0 else math.ceil(self.height / 2)
         self.neighborhoodMode = configuration["neighborhoodMode"]
+        self.wraparound = configuration["wraparound"]
         # Populate grid with NoneType objects
         self.grid = [[None for j in range(height)]for i in range(width)]
 
@@ -86,15 +87,30 @@ class Environment:
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []
-        for i in range(1, gridRange + 1):
-            deltaNorth = (startY - i + self.height) % self.height
-            deltaSouth = (startY + i + self.height) % self.height
-            deltaEast = (startX + i + self.width) % self.width
-            deltaWest = (startX - i + self.width) % self.width
-            cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
-            cellsInRange.append({"cell": self.grid[startX][deltaSouth], "distance": i})
-            cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
-            cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
+        if self.wraparound == True:
+            for i in range(1, gridRange + 1):
+                deltaNorth = startY - i
+                deltaSouth = (startY + i + self.height) % self.height
+                deltaEast = (startX + i + self.width) % self.width
+                deltaWest = startX - i
+                cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
+                cellsInRange.append({"cell": self.grid[startX][deltaSouth], "distance": i})
+                cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
+                cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
+        else:
+            for i in range(1, gridRange + 1):
+                deltaNorth = startY - i
+                deltaSouth = startY + i
+                deltaEast = startX + i
+                deltaWest = startX - i
+                if deltaNorth >= 0:
+                    cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": i})
+                if deltaSouth <= self.height - 1:
+                    cellsInRange.append({"cell": self.grid[startX][deltaSouth], "distance": i})
+                if deltaEast <= self.width - 1:
+                    cellsInRange.append({"cell": self.grid[deltaEast][startY], "distance": i})
+                if deltaWest >= 0:
+                    cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": i})
         return cellsInRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):

--- a/gui.py
+++ b/gui.py
@@ -288,19 +288,11 @@ class GUI:
     def drawLines(self):
         lineCoordinates = set()
         if self.activeNetwork.get() == "Neighbors":
-            if self.sugarscape.environment.neighborhoodMode == "vonNeumann":
-                for agent in self.sugarscape.agents:
-                    for direction, neighbor in agent.vonNeumannNeighbors.items():
-                        if neighbor != None and neighbor.isAlive() == True:
-                            lineEndpointsPair = frozenset([(agent.cell.x, agent.cell.y), (neighbor.cell.x, neighbor.cell.y)])
-                            lineCoordinates.add(lineEndpointsPair)
-            # Moore neighborhoods
-            else:
-                for agent in self.sugarscape.agents:
-                    for direction, neighbor in agent.mooreNeighbors.items():
-                        if neighbor != None and neighbor.isAlive() == True:
-                            lineEndpointsPair = frozenset([(agent.cell.x, agent.cell.y), (neighbor.cell.x, neighbor.cell.y)])
-                            lineCoordinates.add(lineEndpointsPair)
+            for agent in self.sugarscape.agents:
+                for neighbor in agent.socialNeighbors:
+                    if neighbor != None and neighbor.isAlive() == True:
+                        lineEndpointsPair = frozenset([(agent.cell.x, agent.cell.y), (neighbor.cell.x, neighbor.cell.y)])
+                        lineCoordinates.add(lineEndpointsPair)
 
         elif self.activeNetwork.get() == "Family":
             for agent in self.sugarscape.agents:

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -33,7 +33,7 @@ class Sugarscape:
                                     "universalSpiceIncomeInterval": configuration["environmentUniversalSpiceIncomeInterval"],
                                     "universalSugarIncomeInterval": configuration["environmentUniversalSugarIncomeInterval"],
                                     "equator": configuration["environmentEquator"], "sugarscapeSeed": configuration["seed"],
-                                    "neighborhoodMode": configuration["neighborhoodMode"]}
+                                    "neighborhoodMode": configuration["neighborhoodMode"], "wraparound": configuration["environmentWraparound"]}
         self.seed = configuration["seed"]
         self.environment = environment.Environment(configuration["environmentHeight"], configuration["environmentWidth"], self, environmentConfiguration)
         self.environmentHeight = configuration["environmentHeight"]
@@ -1016,6 +1016,7 @@ if __name__ == "__main__":
                      "environmentUniversalSpiceIncomeInterval": 0,
                      "environmentUniversalSugarIncomeInterval": 0,
                      "environmentWidth": 50,
+                     "environmentWraparound": True,
                      "headlessMode": False,
                      "interfaceHeight": 1000,
                      "interfaceWidth": 900,


### PR DESCRIPTION
While working on this, I overhauled agents' Von Neumann and Moore neighbors.
- Removed `agent.vonNeumannNeighbors` and `agent.mooreNeighbors`
- Removed `update*Neighbors()` functions
- Added `agent.socialNeighbors` because we still need asymmetrical adjacency neighborhoods for network overlay
- All other functions that used adjacent neighbors now use `agent.cell.neighbors.values()`
- `cell.neighbors`, previously a list, is now a dictionary with directions. If wraparound is turned off, cells on the edge will just not have directions that go out of bounds. For example, cells on the north edge will not have `"northwest"`, `"north"`, or `"northeast"` in their `cell.neighbors` dictionary.

Possible changes:
- Add another dictionary to distinguish between a cell's Moore and Von Neumann neighbors. `cell.neighbors` uses whichever neighborhood mode you picked in the config.