### PR TITLE
(HOTFIX) Fixes break due to old name of agent.neighbors being used

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -289,7 +289,7 @@ class GUI:
         lineCoordinates = set()
         if self.activeNetwork.get() == "Neighbors":
             for agent in self.sugarscape.agents:
-                for neighbor in agent.socialNeighbors:
+                for neighbor in agent.neighbors:
                     if neighbor != None and neighbor.isAlive() == True:
                         lineEndpointsPair = frozenset([(agent.cell.x, agent.cell.y), (neighbor.cell.x, neighbor.cell.y)])
                         lineCoordinates.add(lineEndpointsPair)


### PR DESCRIPTION
I forgot to rename the `agent.socialNeighbors` in `gui.py` to `agent.neighbors`.