### PR TITLE
Memoizes range for efficiency

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -676,15 +676,14 @@ class Agent:
         return bestFriend
 
     def findCellsInRange(self, newCell=None):
-        cell = self.cell if newCell == None else newCell
         vision = self.findVision()
         movement = self.findMovement()
         cellRange = min(vision, movement)
         if cellRange > 0:
             if (self.visionMode == "cardinal" and cellRange == vision) or (self.movementMode == "cardinal" and cellRange == movement):
-                allCells = self.cell.environment.findCellsInCardinalRange(cell.x, cell.y, cellRange)
+                allCells = self.cell.cardinalRanges[cellRange]
             else:
-                allCells = self.cell.environment.findCellsInRadialRange(cell.x, cell.y, cellRange)
+                allCells = self.cell.radialRanges[cellRange]
             if newCell == None:
                 self.cellsInRange = allCells
             return allCells

--- a/agent.py
+++ b/agent.py
@@ -680,7 +680,7 @@ class Agent:
         cellRange = min(vision, movement)
         allCells = {}
         for i in range(1, cellRange + 1):
-            allCells = {**allCells, **cell.ranges[i]}
+            allCells = allCells.update(cell.ranges[i])
         if newCell == None:
             self.cellsInRange = allCells
         return allCells

--- a/agent.py
+++ b/agent.py
@@ -680,7 +680,7 @@ class Agent:
         cellRange = min(vision, movement)
         allCells = {}
         for i in range(1, cellRange + 1):
-            allCells = allCells.update(cell.ranges[i])
+            allCells.update(cell.ranges[i])
         if newCell == None:
             self.cellsInRange = allCells
         return allCells

--- a/agent.py
+++ b/agent.py
@@ -680,15 +680,12 @@ class Agent:
         vision = self.findVision()
         movement = self.findMovement()
         cellRange = min(vision, movement)
-        if cellRange > 0:
-            if (self.visionMode == "cardinal" and cellRange == vision) or (self.movementMode == "cardinal" and cellRange == movement):
-                allCells = cell.cardinalRanges[cellRange]
-            else:
-                allCells = cell.radialRanges[cellRange]
-            if newCell == None:
-                self.cellsInRange = allCells
-            return allCells
-        return []
+        if cellRange <= 0:
+            return []
+        allCells = cell.ranges[cellRange]
+        if newCell == None:
+            self.cellsInRange = allCells
+        return allCells
 
     def findChildEndowment(self, mate):
         parentEndowments = {

--- a/agent.py
+++ b/agent.py
@@ -682,7 +682,9 @@ class Agent:
         cellRange = min(vision, movement)
         if cellRange <= 0:
             return []
-        allCells = cell.ranges[cellRange][:]
+        allCells = []
+        for i in range(1, cellRange + 1):
+            allCells.extend(cell.ranges[i])
         if newCell == None:
             self.cellsInRange = allCells
         return allCells

--- a/agent.py
+++ b/agent.py
@@ -138,9 +138,8 @@ class Agent:
         self.socialNetwork["creditors"].append(loan)
 
     def canReachCell(self, cell):
-        for seenCell in self.cellsInRange:
-            if seenCell["cell"] == cell:
-                return True
+        if cell == self.cell or cell in self.cellsInRange:
+            return True
         return False
 
     def canTradeWithNeighbor(self, neighbor):
@@ -574,7 +573,8 @@ class Agent:
         self.findNeighborhood()
         if len(self.cellsInRange) == 0:
             return self.cell
-        random.shuffle(self.cellsInRange)
+        cellsInRange = list(self.cellsInRange.items())
+        random.shuffle(cellsInRange)
 
         retaliators = self.findRetaliatorsInVision()
         combatMaxLoot = self.cell.environment.maxCombatLoot
@@ -585,9 +585,7 @@ class Agent:
         bestRange = max(self.cell.environment.height, self.cell.environment.width)
         potentialCells = []
 
-        for currCell in self.cellsInRange:
-            cell = currCell["cell"]
-            travelDistance = currCell["distance"]
+        for cell, travelDistance in cellsInRange:
 
             # Avoid attacking agents ineligible to attack
             prey = cell.agent
@@ -680,11 +678,9 @@ class Agent:
         vision = self.findVision()
         movement = self.findMovement()
         cellRange = min(vision, movement)
-        if cellRange <= 0:
-            return []
-        allCells = []
+        allCells = {}
         for i in range(1, cellRange + 1):
-            allCells.extend(cell.ranges[i])
+            allCells = {**allCells, **cell.ranges[i]}
         if newCell == None:
             self.cellsInRange = allCells
         return allCells
@@ -897,8 +893,8 @@ class Agent:
         else:
             newNeighborhood = self.findCellsInRange(newCell)
         neighborhood = []
-        for neighborCell in newNeighborhood:
-            neighbor = neighborCell["cell"].agent
+        for neighborCell in newNeighborhood.keys():
+            neighbor = neighborCell.agent
             if neighbor != None and neighbor.isAlive() == True:
                 neighborhood.append(neighbor)
         neighborhood.append(self)
@@ -956,8 +952,8 @@ class Agent:
 
     def findRetaliatorsInVision(self):
         retaliators = {}
-        for cell in self.cellsInRange:
-            agent = cell["cell"].agent
+        for cell in self.cellsInRange.keys():
+            agent = cell.agent
             if agent != None:
                 if agent.tribe not in retaliators:
                     retaliators[agent.tribe] = agent.wealth

--- a/agent.py
+++ b/agent.py
@@ -676,14 +676,15 @@ class Agent:
         return bestFriend
 
     def findCellsInRange(self, newCell=None):
+        cell = self.cell if newCell == None else newCell
         vision = self.findVision()
         movement = self.findMovement()
         cellRange = min(vision, movement)
         if cellRange > 0:
             if (self.visionMode == "cardinal" and cellRange == vision) or (self.movementMode == "cardinal" and cellRange == movement):
-                allCells = self.cell.cardinalRanges[cellRange]
+                allCells = cell.cardinalRanges[cellRange]
             else:
-                allCells = self.cell.radialRanges[cellRange]
+                allCells = cell.radialRanges[cellRange]
             if newCell == None:
                 self.cellsInRange = allCells
             return allCells

--- a/agent.py
+++ b/agent.py
@@ -682,7 +682,7 @@ class Agent:
         cellRange = min(vision, movement)
         if cellRange <= 0:
             return []
-        allCells = cell.ranges[cellRange]
+        allCells = cell.ranges[cellRange][:]
         if newCell == None:
             self.cellsInRange = allCells
         return allCells

--- a/agent.py
+++ b/agent.py
@@ -586,7 +586,6 @@ class Agent:
         potentialCells = []
 
         for cell, travelDistance in cellsInRange:
-
             # Avoid attacking agents ineligible to attack
             prey = cell.agent
             if cell.isOccupied() and self.isNeighborValidPrey(prey) == False:

--- a/agent.py
+++ b/agent.py
@@ -679,6 +679,8 @@ class Agent:
         movement = self.findMovement()
         cellRange = min(vision, movement)
         allCells = {}
+        if cellRange <= 0:
+            return allCells
         for i in range(1, cellRange + 1):
             allCells.update(cell.ranges[i])
         if newCell == None:

--- a/cell.py
+++ b/cell.py
@@ -15,6 +15,7 @@ class Cell:
         self.season = None
         self.timestep = 0
         self.neighbors = {}
+        self.ranges = {}
         self.sugarLastProduced = 0
         self.spiceLastProduced = 0
 

--- a/environment.py
+++ b/environment.py
@@ -45,7 +45,6 @@ class Environment:
                 upperDelta = self.findWraparoundDistance(upperDelta, upperBorder)
                 # Delta pair is used as a key to look up hypotenuse
                 deltaPair = (lowerDelta, upperDelta)
-                # print(deltaPair)
                 distanceTable[deltaPair] = math.sqrt(lowerDelta ** 2 + upperDelta ** 2)
         return distanceTable
 

--- a/environment.py
+++ b/environment.py
@@ -97,12 +97,12 @@ class Environment:
             southRange = min(y1 + maxDeltaY, self.height - 1)
             for j in range(x1 + 1, eastRange + 1):
                 deltaX = self.findWraparoundDistance(j - x1, self.width)
-                self.grid[x1][y1].ranges[deltaX].append({"cell": self.grid[j][y1], "distance": deltaX})
-                self.grid[j][y1].ranges[deltaX].append({"cell": self.grid[x1][y1], "distance": deltaX})
+                self.grid[x1][y1].ranges[deltaX][self.grid[j][y1]] = deltaX
+                self.grid[j][y1].ranges[deltaX][self.grid[x1][y1]] = deltaX
             for j in range(y1 + 1, southRange + 1):
                 deltaY = self.findWraparoundDistance(j - y1, self.height)
-                self.grid[x1][y1].ranges[deltaY].append({"cell": self.grid[x1][j], "distance": deltaY})
-                self.grid[x1][j].ranges[deltaY].append({"cell": self.grid[x1][y1], "distance": deltaY})
+                self.grid[x1][y1].ranges[deltaY][self.grid[x1][j]] = deltaY
+                self.grid[x1][j].ranges[deltaY][self.grid[x1][y1]] = deltaY
 
     def findCell(self, x, y):
         return self.grid[x][y]
@@ -123,7 +123,7 @@ class Environment:
         cellCoords = [(x, y) for x in range(self.width) for y in range(self.height)]
         # Initialize ranges with all possible values
         for x, y in cellCoords:
-            self.grid[x][y].ranges = {gridRange: [] for gridRange in range(1, maxDeltaRadius + 1)}
+            self.grid[x][y].ranges = {gridRange: {} for gridRange in range(1, maxDeltaRadius + 1)}
 
         if config["agentVisionMode"] == "radial" and config["agentMovementMode"] == "radial":
             self.findRadialCellRanges(maxDeltaX, maxDeltaY, maxDeltaRadius, cellCoords)
@@ -137,20 +137,14 @@ class Environment:
             x1, y1 = cellCoords[i]
             for j in range(i + 1, numCells):
                 x2, y2 = cellCoords[j]
-                # Skip cells that are out of feasible range
                 deltaX = self.findWraparoundDistance(x1 - x2, self.width)
-                if deltaX > maxDeltaX:
-                    continue
                 deltaY = self.findWraparoundDistance(y1 - y2, self.height)
-                if deltaY > maxDeltaY:
-                    continue
-
                 deltaPair = tuple(sorted((deltaX, deltaY)))
                 distance = distanceTable[deltaPair]
                 gridRange = math.floor(distance)
                 if gridRange <= maxDeltaRadius:
-                    self.grid[x1][y1].ranges[gridRange].append({"cell": self.grid[x2][y2], "distance": distance})
-                    self.grid[x2][y2].ranges[gridRange].append({"cell": self.grid[x1][y1], "distance": distance})
+                    self.grid[x1][y1].ranges[gridRange][self.grid[x2][y2]] = distance
+                    self.grid[x2][y2].ranges[gridRange][self.grid[x1][y1]] = distance
 
     def findWraparoundDistance(self, delta, border):
         delta = abs(delta)

--- a/environment.py
+++ b/environment.py
@@ -36,13 +36,15 @@ class Environment:
     def createDistanceTable(self, maxDeltaX, maxDeltaY):
         distanceTable = {}
         maxOne, maxTwo = sorted([maxDeltaX, maxDeltaY])
-        for deltaOne in range(maxOne + 1):
-            for deltaTwo in range(deltaOne or 1, maxTwo + 1):
-                deltaOne = self.findWraparoundDistance(deltaOne, maxOne)
-                deltaTwo = self.findWraparoundDistance(deltaTwo, maxTwo)
+        lowerMax = min(maxDeltaX, maxDeltaY)
+        upperMax = max(maxDeltaX, maxDeltaY)
+        for lowerDelta in range(lowerMax + 1):
+            for upperDelta in range(max(1, lowerDelta), upperMax + 1):
+                lowerDelta = self.findWraparoundDistance(lowerDelta, lowerMax)
+                upperDelta = self.findWraparoundDistance(upperDelta, upperMax)
                 # Delta pair is used as a key to look up hypotenuse
-                deltaPair = (deltaOne, deltaTwo)
-                distanceTable[deltaPair] = math.sqrt(deltaOne ** 2 + deltaTwo ** 2)
+                deltaPair = (lowerDelta, upperDelta)
+                distanceTable[deltaPair] = math.sqrt(lowerDelta ** 2 + upperDelta ** 2)
         return distanceTable
 
     def doCellUpdate(self):
@@ -114,6 +116,7 @@ class Environment:
 
     def findCellRanges(self):
         config = self.sugarscape.configuration
+        # Determine maximum range to memoize based on the maximum possible agent vision and movement from bonuses
         maxVision = config["startingDiseases"] * max(config["diseaseVisionPenalty"][1], 0) + config["agentVision"][1]
         maxMovement = config["startingDiseases"] * max(config["diseaseMovementPenalty"][1], 0) + config["agentMovement"][1]
         maxAgentRange = max(maxVision, maxMovement)

--- a/environment.py
+++ b/environment.py
@@ -85,6 +85,20 @@ class Environment:
             for j in range(self.height):
                 self.grid[i][j].findNeighbors(self.neighborhoodMode)
 
+    def findCellRanges(self):
+        for i in range(self.width):
+            for j in range(self.height):
+                cell = self.grid[i][j]
+                cell.cardinalRanges = {}
+                cell.radialRanges = {}
+                minDistance = min(self.sugarscape.configuration["agentVision"][0], self.sugarscape.configuration["agentMovement"][0])
+                maxDistance = max(self.sugarscape.configuration["agentVision"][1], self.sugarscape.configuration["agentMovement"][1])
+                for distance in range(minDistance, maxDistance + 1):
+                    if self.sugarscape.configuration["agentVisionMode"] == "cardinal" or self.sugarscape.configuration["agentMovementMode"] == "cardinal":
+                        cell.cardinalRanges[distance] = self.findCellsInCardinalRange(cell.x, cell.y, distance)
+                    if self.sugarscape.configuration["agentVisionMode"] == "radial" or self.sugarscape.configuration["agentMovementMode"] == "radial":
+                        cell.radialRanges[distance] = self.findCellsInRadialRange(cell.x, cell.y, distance)
+
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []
         if self.wraparound == True:

--- a/environment.py
+++ b/environment.py
@@ -95,7 +95,6 @@ class Environment:
         for i in range(self.width):
             for j in range(self.height):
                 cell = self.grid[i][j]
-                cell.ranges = {}
                 for distance in range(minDistance, maxDistance + 1):
                     cell.ranges[distance] = findCellsInModeRange(cell.x, cell.y, distance)
 

--- a/environment.py
+++ b/environment.py
@@ -123,12 +123,15 @@ class Environment:
     def findCellsAtRadialRange(self, startX, startY, gridRange):
         cellsInPreviousRange = self.findCellsInRadialRange(startX, startY, gridRange - 1)
         cellsInCurrentRange = self.findCellsInRadialRange(startX, startY, gridRange)
-        cellsAtRange = [cellRecord for cellRecord in cellsInCurrentRange if cellRecord not in cellsInPreviousRange]
+        previousRangeSet = {tuple(cellRecord.items()) for cellRecord in cellsInPreviousRange}
+        cellsAtRange = [cellRecord for cellRecord in cellsInCurrentRange if tuple(cellRecord.items()) not in previousRangeSet]
         return cellsAtRange
 
     def findCellsInRadialRange(self, startX, startY, gridRange):
         if self.wraparound == True:
-            cellsInRange = [self.findCellsAtCardinalRange(startX, startY, i) for i in range(1, gridRange + 1)]
+            cellsInRange = []
+            for i in range(1, gridRange + 1):
+                cellsInRange.extend(self.findCellsAtCardinalRange(startX, startY, i))
             # Iterate through the upper left quadrant of the circle's bounding box
             for deltaX in range(startX - gridRange, startX):
                 for deltaY in range(startY - gridRange, startY):

--- a/environment.py
+++ b/environment.py
@@ -89,10 +89,9 @@ class Environment:
         config = self.sugarscape.configuration
         if config["agentVisionMode"] == "radial" and config["agentMovementMode"] == "radial":
             findCellsInModeRange = self.findCellsAtRadialRange
-            maxDistance = math.ceil(math.hypot(self.width, self.height))
         else:
             findCellsInModeRange = self.findCellsAtCardinalRange
-            maxDistance = max(self.width, self.height)
+        maxDistance = max(self.width, self.height)
         for i in range(self.width):
             for j in range(self.height):
                 cell = self.grid[i][j]
@@ -106,10 +105,10 @@ class Environment:
         deltaEast = startX + gridRange
         deltaWest = startX - gridRange
         if self.wraparound == True:
-            cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": gridRange})
+            cellsInRange.append({"cell": self.grid[startX][(deltaNorth + self.height) % self.height], "distance": gridRange})
             cellsInRange.append({"cell": self.grid[startX][(deltaSouth + self.height) % self.height], "distance": gridRange})
             cellsInRange.append({"cell": self.grid[(deltaEast + self.width) % self.width][startY], "distance": gridRange})
-            cellsInRange.append({"cell": self.grid[deltaWest][startY], "distance": gridRange})
+            cellsInRange.append({"cell": self.grid[(deltaWest + self.width) % self.width][startY], "distance": gridRange})
         else:
             if deltaNorth >= 0:
                 cellsInRange.append({"cell": self.grid[startX][deltaNorth], "distance": gridRange})
@@ -122,8 +121,8 @@ class Environment:
         return cellsInRange
 
     def findCellsAtRadialRange(self, startX, startY, gridRange):
-        cellsInPreviousRange = self.findCellsInRadialRange(gridRange - 1)
-        cellsInCurrentRange = self.findCellsInRadialRange(gridRange)
+        cellsInPreviousRange = self.findCellsInRadialRange(startX, startY, gridRange - 1)
+        cellsInCurrentRange = self.findCellsInRadialRange(startX, startY, gridRange)
         cellsAtRange = [cellRecord for cellRecord in cellsInCurrentRange if cellRecord not in cellsInPreviousRange]
         return cellsAtRange
 
@@ -133,6 +132,8 @@ class Environment:
             # Iterate through the upper left quadrant of the circle's bounding box
             for deltaX in range(startX - gridRange, startX):
                 for deltaY in range(startY - gridRange, startY):
+                    deltaX = (deltaX + self.width) % self.width
+                    deltaY = (deltaY + self.height) % self.height 
                     euclideanDistance = math.sqrt(pow((deltaX - startX), 2) + pow((deltaY - startY), 2))
                     # If agent can see at least part of a cell, they should be allowed to consider it
                     if euclideanDistance < gridRange + 1 and self.grid[deltaX][deltaY] != self.grid[startX][startY]:

--- a/environment.py
+++ b/environment.py
@@ -86,9 +86,20 @@ class Environment:
                 self.grid[i][j].findNeighbors(self.neighborhoodMode)
 
     def findCellRanges(self):
-        minDistance = min(self.sugarscape.configuration["agentVision"][0], self.sugarscape.configuration["agentMovement"][0])
-        maxDistance = min(self.sugarscape.configuration["agentVision"][1], self.sugarscape.configuration["agentMovement"][1])
-        if self.sugarscape.configuration["agentVisionMode"] == "radial" and self.sugarscape.configuration["agentMovementMode"] == "radial":
+        config = self.sugarscape.configuration
+        minVisionPenalty = min(config["diseaseVisionPenalty"][0], 0)
+        minVision = config["agentVision"][0] + minVisionPenalty
+        minMovementPenalty = min(config["diseaseMovementPenalty"][0], 0)
+        minMovement = config["agentMovement"][0] + minMovementPenalty
+        minDistance = min(minVision, minMovement)
+
+        maxVisionPenalty = max(config["diseaseVisionPenalty"][1], 0)
+        maxVision = config["agentVision"][1] + maxVisionPenalty
+        maxMovementPenalty = max(config["diseaseMovementPenalty"][1], 0)
+        maxMovement = config["agentMovement"][1] + maxMovementPenalty
+        maxDistance = max(maxVision, maxMovement)
+        print(minDistance, maxDistance)
+        if config["agentVisionMode"] == "radial" and config["agentMovementMode"] == "radial":
             findCellsInModeRange = self.findCellsInRadialRange
         else:
             findCellsInModeRange = self.findCellsInCardinalRange

--- a/environment.py
+++ b/environment.py
@@ -88,15 +88,16 @@ class Environment:
     def findCellRanges(self):
         minDistance = min(self.sugarscape.configuration["agentVision"][0], self.sugarscape.configuration["agentMovement"][0])
         maxDistance = min(self.sugarscape.configuration["agentVision"][1], self.sugarscape.configuration["agentMovement"][1])
+        if self.sugarscape.configuration["agentVisionMode"] == "radial" and self.sugarscape.configuration["agentMovementMode"] == "radial":
+            findCellsInModeRange = self.findCellsInRadialRange
+        else:
+            findCellsInModeRange = self.findCellsInCardinalRange
         for i in range(self.width):
             for j in range(self.height):
                 cell = self.grid[i][j]
                 cell.ranges = {}
                 for distance in range(minDistance, maxDistance + 1):
-                    if self.sugarscape.configuration["agentVisionMode"] == "radial" and self.sugarscape.configuration["agentMovementMode"] == "radial":
-                        cell.ranges[distance] = self.findCellsInRadialRange(cell.x, cell.y, distance)
-                    else:
-                        cell.ranges[distance] = self.findCellsInCardinalRange(cell.x, cell.y, distance)
+                    cell.ranges[distance] = findCellsInModeRange(cell.x, cell.y, distance)
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []

--- a/environment.py
+++ b/environment.py
@@ -88,15 +88,15 @@ class Environment:
     def findCellRanges(self):
         config = self.sugarscape.configuration
         if config["agentVisionMode"] == "radial" and config["agentMovementMode"] == "radial":
-            findCellsInModeRange = self.findCellsAtRadialRange
+            findCellsAtModeRange = self.findCellsAtRadialRange
         else:
-            findCellsInModeRange = self.findCellsAtCardinalRange
+            findCellsAtModeRange = self.findCellsAtCardinalRange
         maxDistance = max(self.width, self.height)
         for i in range(self.width):
             for j in range(self.height):
                 cell = self.grid[i][j]
                 for distance in range(1, maxDistance):
-                    cell.ranges[distance] = findCellsInModeRange(cell.x, cell.y, distance)
+                    cell.ranges[distance] = findCellsAtModeRange(cell.x, cell.y, distance)
 
     def findCellsAtCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []
@@ -132,8 +132,6 @@ class Environment:
             # Iterate through the upper left quadrant of the circle's bounding box
             for deltaX in range(startX - gridRange, startX):
                 for deltaY in range(startY - gridRange, startY):
-                    deltaX = (deltaX + self.width) % self.width
-                    deltaY = (deltaY + self.height) % self.height 
                     euclideanDistance = math.sqrt(pow((deltaX - startX), 2) + pow((deltaY - startY), 2))
                     # If agent can see at least part of a cell, they should be allowed to consider it
                     if euclideanDistance < gridRange + 1 and self.grid[deltaX][deltaY] != self.grid[startX][startY]:

--- a/environment.py
+++ b/environment.py
@@ -126,7 +126,7 @@ class Environment:
             # Iterate through the upper left quadrant of the circle's bounding box
             for deltaX in range(startX - gridRange, startX):
                 for deltaY in range(startY - gridRange, startY):
-                    euclideanDistance = math.hypot(deltaX - startX, deltaY - startY)
+                    euclideanDistance = math.sqrt((deltaX - startX) ** 2 + (deltaY - startY) ** 2)
                     # If agent can see at least part of a cell, they should be allowed to consider it
                     if euclideanDistance < gridRange + 1 and euclideanDistance >= gridRange and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
                         reflectedX = (2 * startX - deltaX + self.width) % self.width
@@ -141,7 +141,7 @@ class Environment:
             for deltaX in range(max(0, startX - gridRange), min(self.width, startX + gridRange + 1)):
                 for deltaY in range(max(0, startY - gridRange), min(self.height, startY + gridRange + 1)):
                     # If agent can see at least part of a cell, they should be allowed to consider it
-                    euclideanDistance = math.hypot(deltaX - startX, deltaY - startY)
+                    euclideanDistance = math.sqrt((deltaX - startX) ** 2 + (deltaY - startY) ** 2)
                     if euclideanDistance < gridRange + 1 and euclideanDistance >= gridRange and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
                         cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
         return cellsInRange

--- a/environment.py
+++ b/environment.py
@@ -86,13 +86,13 @@ class Environment:
                 self.grid[i][j].findNeighbors(self.neighborhoodMode)
 
     def findCellRanges(self):
+        minDistance = min(self.sugarscape.configuration["agentVision"][0], self.sugarscape.configuration["agentMovement"][0])
+        maxDistance = min(self.sugarscape.configuration["agentVision"][1], self.sugarscape.configuration["agentMovement"][1])
         for i in range(self.width):
             for j in range(self.height):
                 cell = self.grid[i][j]
                 cell.cardinalRanges = {}
                 cell.radialRanges = {}
-                minDistance = min(self.sugarscape.configuration["agentVision"][0], self.sugarscape.configuration["agentMovement"][0])
-                maxDistance = max(self.sugarscape.configuration["agentVision"][1], self.sugarscape.configuration["agentMovement"][1])
                 for distance in range(minDistance, maxDistance + 1):
                     if self.sugarscape.configuration["agentVisionMode"] == "cardinal" or self.sugarscape.configuration["agentMovementMode"] == "cardinal":
                         cell.cardinalRanges[distance] = self.findCellsInCardinalRange(cell.x, cell.y, distance)

--- a/environment.py
+++ b/environment.py
@@ -35,7 +35,6 @@ class Environment:
 
     def createDistanceTable(self, maxDeltaX, maxDeltaY):
         distanceTable = {}
-        maxOne, maxTwo = sorted([maxDeltaX, maxDeltaY])
         lowerMax = min(maxDeltaX, maxDeltaY)
         upperMax = max(maxDeltaX, maxDeltaY)
         for lowerDelta in range(lowerMax + 1):
@@ -142,6 +141,8 @@ class Environment:
                 x2, y2 = cellCoords[j]
                 deltaX = self.findWraparoundDistance(x1 - x2, self.width)
                 deltaY = self.findWraparoundDistance(y1 - y2, self.height)
+                if deltaX > maxDeltaX or deltaY > maxDeltaY:
+                    continue
                 deltaPair = tuple(sorted((deltaX, deltaY)))
                 distance = distanceTable[deltaPair]
                 gridRange = math.floor(distance)

--- a/environment.py
+++ b/environment.py
@@ -91,13 +91,12 @@ class Environment:
         for i in range(self.width):
             for j in range(self.height):
                 cell = self.grid[i][j]
-                cell.cardinalRanges = {}
-                cell.radialRanges = {}
+                cell.ranges = {}
                 for distance in range(minDistance, maxDistance + 1):
-                    if self.sugarscape.configuration["agentVisionMode"] == "cardinal" or self.sugarscape.configuration["agentMovementMode"] == "cardinal":
-                        cell.cardinalRanges[distance] = self.findCellsInCardinalRange(cell.x, cell.y, distance)
-                    if self.sugarscape.configuration["agentVisionMode"] == "radial" or self.sugarscape.configuration["agentMovementMode"] == "radial":
-                        cell.radialRanges[distance] = self.findCellsInRadialRange(cell.x, cell.y, distance)
+                    if self.sugarscape.configuration["agentVisionMode"] == "radial" and self.sugarscape.configuration["agentMovementMode"] == "radial":
+                        cell.ranges[distance] = self.findCellsInRadialRange(cell.x, cell.y, distance)
+                    else:
+                        cell.ranges[distance] = self.findCellsInCardinalRange(cell.x, cell.y, distance)
 
     def findCellsInCardinalRange(self, startX, startY, gridRange):
         cellsInRange = []

--- a/environment.py
+++ b/environment.py
@@ -121,10 +121,8 @@ class Environment:
         return cellsInRange
 
     def findCellsAtRadialRange(self, startX, startY, gridRange):
-        cellsInRange = []
         if self.wraparound == True:
-            for i in range(1, gridRange + 1):
-                cellsInRange.extend(self.findCellsAtCardinalRange(startX, startY, i))
+            cellsInRange = self.findCellsAtCardinalRange(startX, startY, gridRange)
             # Iterate through the upper left quadrant of the circle's bounding box
             for deltaX in range(startX - gridRange, startX):
                 for deltaY in range(startY - gridRange, startY):
@@ -138,6 +136,7 @@ class Environment:
                         cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
                         cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})        
         else:
+            cellsInRange = []
             # Iterate through the bounding box of the circle
             for deltaX in range(max(0, startX - gridRange), min(self.width, startX + gridRange + 1)):
                 for deltaY in range(max(0, startY - gridRange), min(self.height, startY + gridRange + 1)):

--- a/environment.py
+++ b/environment.py
@@ -37,12 +37,15 @@ class Environment:
         distanceTable = {}
         lowerMax = min(maxDeltaX, maxDeltaY)
         upperMax = max(maxDeltaX, maxDeltaY)
+        lowerBorder = self.width if lowerMax == maxDeltaX else self.height
+        upperBorder = self.width if lowerMax == maxDeltaY else self.height
         for lowerDelta in range(lowerMax + 1):
             for upperDelta in range(max(1, lowerDelta), upperMax + 1):
-                lowerDelta = self.findWraparoundDistance(lowerDelta, lowerMax)
-                upperDelta = self.findWraparoundDistance(upperDelta, upperMax)
+                lowerDelta = self.findWraparoundDistance(lowerDelta, lowerBorder)
+                upperDelta = self.findWraparoundDistance(upperDelta, upperBorder)
                 # Delta pair is used as a key to look up hypotenuse
                 deltaPair = (lowerDelta, upperDelta)
+                # print(deltaPair)
                 distanceTable[deltaPair] = math.sqrt(lowerDelta ** 2 + upperDelta ** 2)
         return distanceTable
 

--- a/environment.py
+++ b/environment.py
@@ -121,23 +121,16 @@ class Environment:
         return cellsInRange
 
     def findCellsAtRadialRange(self, startX, startY, gridRange):
-        cellsInPreviousRange = self.findCellsInRadialRange(startX, startY, gridRange - 1)
-        cellsInCurrentRange = self.findCellsInRadialRange(startX, startY, gridRange)
-        previousRangeSet = {tuple(cellRecord.items()) for cellRecord in cellsInPreviousRange}
-        cellsAtRange = [cellRecord for cellRecord in cellsInCurrentRange if tuple(cellRecord.items()) not in previousRangeSet]
-        return cellsAtRange
-
-    def findCellsInRadialRange(self, startX, startY, gridRange):
+        cellsInRange = []
         if self.wraparound == True:
-            cellsInRange = []
             for i in range(1, gridRange + 1):
                 cellsInRange.extend(self.findCellsAtCardinalRange(startX, startY, i))
             # Iterate through the upper left quadrant of the circle's bounding box
             for deltaX in range(startX - gridRange, startX):
                 for deltaY in range(startY - gridRange, startY):
-                    euclideanDistance = math.sqrt(pow((deltaX - startX), 2) + pow((deltaY - startY), 2))
+                    euclideanDistance = math.hypot(deltaX - startX, deltaY - startY)
                     # If agent can see at least part of a cell, they should be allowed to consider it
-                    if euclideanDistance < gridRange + 1 and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
+                    if euclideanDistance < gridRange + 1 and euclideanDistance >= gridRange and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
                         reflectedX = (2 * startX - deltaX + self.width) % self.width
                         reflectedY = (2 * startY - deltaY + self.height) % self.height
                         cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
@@ -145,13 +138,12 @@ class Environment:
                         cellsInRange.append({"cell": self.grid[reflectedX][deltaY], "distance": euclideanDistance})
                         cellsInRange.append({"cell": self.grid[reflectedX][reflectedY], "distance": euclideanDistance})        
         else:
-            cellsInRange = []
             # Iterate through the bounding box of the circle
             for deltaX in range(max(0, startX - gridRange), min(self.width, startX + gridRange + 1)):
                 for deltaY in range(max(0, startY - gridRange), min(self.height, startY + gridRange + 1)):
                     # If agent can see at least part of a cell, they should be allowed to consider it
-                    euclideanDistance = math.sqrt(pow((deltaX - startX), 2) + pow((deltaY - startY), 2))
-                    if euclideanDistance < gridRange + 1 and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
+                    euclideanDistance = math.hypot(deltaX - startX, deltaY - startY)
+                    if euclideanDistance < gridRange + 1 and euclideanDistance >= gridRange and self.grid[deltaX][deltaY] != self.grid[startX][startY]:
                         cellsInRange.append({"cell": self.grid[deltaX][deltaY], "distance": euclideanDistance})
         return cellsInRange
 

--- a/environment.py
+++ b/environment.py
@@ -37,9 +37,9 @@ class Environment:
         distanceTable = {}
         for deltaX in range(maxCellRange + 1):
             for deltaY in range(maxCellRange + 1):
-                # Find distances accounting for wraparound
                 deltaX = self.findWraparoundDistance(deltaX, self.width)
                 deltaY = self.findWraparoundDistance(deltaY, self.height)
+                # Delta pair is used as a key to look up hypotenuse
                 deltaXY = tuple(sorted((deltaX, deltaY)))
                 distanceTable[deltaXY] = math.sqrt(deltaX ** 2 + deltaY ** 2)
         return distanceTable
@@ -121,7 +121,7 @@ class Environment:
 
         cellCoords = [(x, y) for x in range(self.width) for y in range(self.height)]
         numCells = self.width * self.height
-        # Initialize cell.ranges with necessary range values
+        # Initialize ranges with all possible values
         for x, y in cellCoords:
             self.grid[x][y].ranges = {gridRange: [] for gridRange in range(maxCellRange + 1)}
 
@@ -131,7 +131,7 @@ class Environment:
             self.findCardinalCellRanges(maxCellRange, cellCoords, numCells)
 
     def findRadialCellRanges(self, maxCellRange, cellCoords, numCells):
-        self.distanceTable = self.createDistanceTable(maxCellRange)
+        distanceTable = self.createDistanceTable(maxCellRange)
         for i in range(numCells):
             x1, y1 = cellCoords[i]
             for j in range(i + 1, numCells):
@@ -142,7 +142,7 @@ class Environment:
                 if deltaX > maxCellRange or deltaY > maxCellRange:
                     continue
 
-                distance = self.distanceTable[tuple(sorted((deltaX, deltaY)))]
+                distance = distanceTable[tuple(sorted((deltaX, deltaY)))]
                 gridRange = math.floor(distance)
                 if gridRange <= maxCellRange:
                     self.grid[x1][y1].ranges[gridRange].append({"cell": self.grid[x2][y2], "distance": distance})

--- a/ethics.py
+++ b/ethics.py
@@ -23,7 +23,7 @@ class Bentham(agent.Agent):
         futureNeighborhoodSize = len(self.findNeighborhood(cell))
         for neighbor in self.neighborhood:
             certainty = 1 if neighbor.canReachCell(cell) == True else 0
-            # Skip calculations that will end up being a 0
+            # Skip if agent cannot reach cell
             if certainty == 0:
                 continue
             # Timesteps to reach cell, currently 1 since agents only plan for the current timestep

--- a/ethics.py
+++ b/ethics.py
@@ -22,13 +22,15 @@ class Bentham(agent.Agent):
         neighborhoodSize = len(self.neighborhood)
         futureNeighborhoodSize = len(self.findNeighborhood(cell))
         for neighbor in self.neighborhood:
-            neighborReach = min(neighbor.findVision(), neighbor.findMovement())
+            certainty = 1 if neighbor.canReachCell(cell) == True else 0
+            # Skip calculations that will end up being a 0
+            if certainty == 0:
+                continue
             # Timesteps to reach cell, currently 1 since agents only plan for the current timestep
             timestepDistance = 1
             neighborMetabolism = neighbor.sugarMetabolism + neighbor.spiceMetabolism
             # If agent does not have metabolism, set duration to seemingly infinite
             cellDuration = cellSiteWealth / neighborMetabolism if neighborMetabolism > 0 else 0
-            certainty = 1 if neighbor.canReachCell(cell) == True else 0
             proximity = 1 / timestepDistance
             intensity = (1 / (1 + neighbor.findTimeToLive()) / (1 + cell.pollution))
             duration = cellDuration / cellMaxSiteWealth if cellMaxSiteWealth > 0 else 0
@@ -40,7 +42,7 @@ class Bentham(agent.Agent):
             cellNeighbors = len(neighbor.cell.neighbors)
             futureIntensity = cellNeighborWealth / (globalMaxWealth * cellNeighbors)
             # Normalize extent by total cells in range
-            cellsInRange = len(neighbor.cellsInRange) if neighborReach > 0 else 0
+            cellsInRange = len(neighbor.cellsInRange)
             extent = neighborhoodSize / cellsInRange if cellsInRange > 0 else 1
             futureExtent = futureNeighborhoodSize / cellsInRange if cellsInRange > 0 and self.lookahead != None else 1
             neighborCellValue = 0

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -197,6 +197,7 @@ class Sugarscape:
         for peak in spicePeaks:
             self.addSpicePeak(peak[0], peak[1], radius, maxSpice)
         self.environment.findCellNeighbors()
+        self.environment.findCellRanges()
 
     def doTimestep(self):
         self.removeDeadAgents()


### PR DESCRIPTION
This breaks determinism, but only because the order of cells in agents' `cellsInRange` changes. I'm looking into why, because the order should really be the same. Also, a good next step to optimize `findNeighborhood` would be to make `cellsInRange` a set and find its intersection with `Sugarscape`'s `self.agents` list.

If the memoization takes up too much storage, we can instead store the difference between the current range and the previous range (the additional cells added) rather than storing the whole list for every distance.