### PR TITLE
Fixes break with zero tribes and nonzero tag string length

### DIFF
--- a/sugarscape.py
+++ b/sugarscape.py
@@ -520,7 +520,7 @@ class Sugarscape:
                 if configurations[config]["curr"] > configurations[config]["max"]:
                     configurations[config]["curr"] = configurations[config]["min"]
 
-            if tagStringLength > 0:
+            if tagStringLength > 0 and configs["environmentMaxTribes"] > 0:
                 tags.append([random.randrange(2) for i in range(tagStringLength)])
             else:
                 tags.append(None)


### PR DESCRIPTION
This will change random states for immune system creation. It might not be necessary, but I found it in my testing.