### PR TITLE
Modifies some f-strings to single quotation marks instead of double quotation marks

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1192,7 +1192,7 @@ class Agent:
         i = 0
         while i < len(cells):
             cell = cells[i]
-            cellString = f"({cell["cell"].x},{cell["cell"].y}) [{cell["wealth"]},{cell["range"]}]"
+            cellString = f"({cell['cell'].x},{cell['cell'].y}) [{cell['wealth']},{cell['range']}]"
             print(f"Cell {i + 1}/{len(cells)}: {cellString}")
             i += 1
 
@@ -1200,7 +1200,7 @@ class Agent:
         i = 0
         while i < len(cells):
             cell = cells[i]
-            cellString = f"({cell["cell"].x},{cell["cell"].y}) [{cell["wealth"]},{cell["range"]}]"
+            cellString = f"({cell['cell'].x},{cell['cell'].y}) [{cell['wealth']},{cell['range']}]"
             print(f"Ethical cell {i + 1}/{len(cells)}: {cellString}")
             i += 1
 

--- a/gui.py
+++ b/gui.py
@@ -518,7 +518,7 @@ class GUI:
 
     def updateLabels(self):
         stats = self.sugarscape.runtimeStats
-        statsString = f"Timestep: {self.sugarscape.timestep} | Agents: {stats["population"]} | Metabolism: {stats["meanMetabolism"]} | Movement: {stats["meanMovement"]} | Vision: {stats["meanVision"]} | Gini: {stats["giniCoefficient"]} | Trade Price: {stats["meanTradePrice"]} | Trade Volume: {stats["tradeVolume"]}"
+        statsString = f"Timestep: {self.sugarscape.timestep} | Agents: {stats['population']} | Metabolism: {stats['meanMetabolism']} | Movement: {stats['meanMovement']} | Vision: {stats['meanVision']} | Gini: {stats['giniCoefficient']} | Trade Price: {stats['meanTradePrice']} | Trade Volume: {stats['tradeVolume']}"
         label = self.widgets["statsLabel"]
         label.config(text=statsString)
         if self.highlightedCell != None:

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -907,7 +907,7 @@ def verifyConfiguration(configuration):
     totalCells = totalCells * (configuration["environmentQuadrantSizeFactor"] ** 2) * len(configuration["agentStartingQuadrants"]) / 4
     if configuration["startingAgents"] > totalCells:
         if "all" in configuration["debugMode"] or "sugarscape" in configuration["debugMode"]:
-            print(f"Could not allocate {configuration["startingAgents"]} agents. Allocating maximum of {totalCells}.")
+            print(f"Could not allocate {configuration['startingAgents']} agents. Allocating maximum of {totalCells}.")
         configuration["startingAgents"] = totalCells
 
     # Ensure infinitely-lived agents are properly initialized


### PR DESCRIPTION
A few f-strings were parsing json file references and threw errors at the double quotation marks, so I replaced them with single quotes. 