### PR TITLE
Prevents inherited curses creating zombie agents

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -261,6 +261,11 @@ class Agent:
     def doInheritance(self):
         if self.inheritancePolicy == "none":
             return
+        # Prevent negative inheritance
+        if self.sugar < 0:
+            self.sugar = 0
+        if self.spice < 0:
+            self.spice = 0
         # Provide inheritance for living children/sons/daughters/friends
         livingChildren = []
         livingSons = []


### PR DESCRIPTION
When an agent dies from starvation, their sugar or spice can be negative. Attempting to pass on this negative wealth to children or other heirs results in the heirs _losing_ wealth instead of gaining wealth. If heirs have already completed their timestep but this curse brings one of their resources into the negative, they will be removed from `Sugarscape`'s `self.agents` by `removeDeadAgents` without going through the proper `doDeath` process. This results in zombie agents that are kept alive by their cells referencing them and eventually overwritten when a new agent enters the cell.