### PR TITLE
Fixes Gini coefficient

### DIFF
--- a/sugarscape.py
+++ b/sugarscape.py
@@ -683,8 +683,9 @@ class Sugarscape:
             cumulativeWealth += wealth
             lorenzCurveArea += cumulativeWealth / totalWealth
         lorenzCurveArea /= len(agentWealths)
-
-        giniCoefficient = round((0.5 - lorenzCurveArea) / 0.5, 2)
+        # When normalized, the triangle under the equality line has base and height 1
+        equalityLineArea = 0.5
+        giniCoefficient = round((equalityLineArea - lorenzCurveArea) / equalityLineArea, 3)
         return giniCoefficient
 
     def updateRuntimeStats(self):

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -674,15 +674,17 @@ class Sugarscape:
         self.run = not self.run
 
     def updateGiniCoefficient(self):
-        agentWealths = sorted([agent.wealth for agent in self.agents])
-        # Calculate area between line of equality and Lorenz curve of agent wealths
-        height = 0
-        area = 0
+        agentWealths = sorted([agent.sugar + agent.spice for agent in self.agents])
+        # Calculate normalized area of Lorenz curve of agent wealths
+        totalWealth = sum(agentWealths)
+        cumulativeWealth = 0
+        lorenzCurveArea = 0
         for wealth in agentWealths:
-            height += wealth
-            area += (height - wealth) / 2
-        lineOfEquality = (height * len(agentWealths)) / 2
-        giniCoefficient = round((lineOfEquality - area) / max(1, lineOfEquality), 2)
+            cumulativeWealth += wealth
+            lorenzCurveArea += cumulativeWealth / totalWealth
+        lorenzCurveArea /= len(agentWealths)
+
+        giniCoefficient = round((0.5 - lorenzCurveArea) / 0.5, 2)
         return giniCoefficient
 
     def updateRuntimeStats(self):

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -683,7 +683,7 @@ class Sugarscape:
             cumulativeWealth += wealth
             lorenzCurveArea += cumulativeWealth / totalWealth
         lorenzCurveArea /= len(agentWealths)
-        # When normalized, the triangle under the equality line has base and height 1
+        # The total area under the equality line will be 0.5
         equalityLineArea = 0.5
         giniCoefficient = round((equalityLineArea - lorenzCurveArea) / equalityLineArea, 3)
         return giniCoefficient


### PR DESCRIPTION
The main problems were:
- Using `agent.wealth` (see my email)
- If `area += (height - wealth) / 2` is supposed to calculate the area _under_ the Lorenz curve, it should just be `area += height`. If it's supposed to calculate the area between the line of equality and the Lorenz curve, then it doesn't work because the `giniCoefficient =` line treats it as the area under the Lorenz curve (among other reasons).

I can rework it to still calculate the area under the line of equality if you don't like the magic number 0.5, but it seems intuitive to normalize it.