### PR TITLE
Fixes bug where agents with zero range move

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -675,6 +675,7 @@ class Agent:
         cellRange = min(vision, movement)
         allCells = {}
         if cellRange <= 0:
+            self.cellsInRange = allCells
             return allCells
         for i in range(1, cellRange + 1):
             allCells.update(cell.ranges[i])


### PR DESCRIPTION
I noticed that a few cardinal agents were moving diagonally. On seed `7994924011103639114`, agent 107 starts at cell (25, 7) and moves diagonally within the first few timesteps. Turns out agents with zero range were still being allowed to use the cells in range from the end of their previous timestep.