### PR TITLE
Fixes break when meanWealth = 1

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1002,7 +1002,7 @@ class Agent:
 
     def findWealthHappiness(self):
         wealth = self.sugar + self.spice
-        if self.cell.environment.sugarscape.runtimeStats["meanWealth"] < 1:
+        if self.cell.environment.sugarscape.runtimeStats["meanWealth"] <= 1:
             return 0
         elif wealth < 1:
             return -1


### PR DESCRIPTION
Log base 1 is undefined. In cases of extreme inequality, the meanWealth metric will gradually decrease to 1, causing a break.