### PR TITLE
Fixes negative Gini coefficient for smaller populations

### DIFF
--- a/sugarscape.py
+++ b/sugarscape.py
@@ -679,13 +679,17 @@ class Sugarscape:
     def updateGiniCoefficient(self):
         agentWealths = sorted([agent.sugar + agent.spice for agent in self.agents])
         # Calculate normalized area of Lorenz curve of agent wealths
+        numAgents = len(agentWealths)
         totalWealth = sum(agentWealths)
         cumulativeWealth = 0
         lorenzCurveArea = 0
-        for wealth in agentWealths:
-            cumulativeWealth += wealth
+        for i in range(numAgents - 1):
+            cumulativeWealth += agentWealths[i]
             lorenzCurveArea += cumulativeWealth / totalWealth
-        lorenzCurveArea /= len(agentWealths)
+        # Use trapezoidal area to maintain accuracy with smaller populations
+        cumulativeWealth += agentWealths[-1]
+        lorenzCurveArea += (cumulativeWealth / 2) / totalWealth
+        lorenzCurveArea /= numAgents
         # The total area under the equality line will be 0.5
         equalityLineArea = 0.5
         giniCoefficient = round((equalityLineArea - lorenzCurveArea) / equalityLineArea, 3)


### PR DESCRIPTION
The current Gini coefficient is inaccurate for smaller populations—the rectangular area of the wealthiest agent can spill over the equality line and result in a negative ratio. Using trapezoidal area instead ensures that the Lorenz curve area is more accurate and always stays under the equality line.