### PR TITLE
Fixes break when typechecking empty list

### DIFF
--- a/sugarscape.py
+++ b/sugarscape.py
@@ -995,6 +995,8 @@ def verifyConfiguration(configuration):
     negativeFlag = 0
     for configName, configValue in configuration.items():
         if isinstance(configValue, list):
+            if len(configValue) == 0:
+                continue
             configType = type(configValue[0])
             if configName != "environmentPollutionDiffusionTimeFrame" and configName != "environmentPollutionTimeFrame":
                 configValue.sort()


### PR DESCRIPTION
There are a few config settings that can be empty lists, like `environmentStartingQuadrants` and `environment*Peaks`. Checking the type of the first element causes a break.