### PR TITLE
Fixes bug where too many replacement agents are created

### DIFF
--- a/sugarscape.py
+++ b/sugarscape.py
@@ -106,7 +106,7 @@ class Sugarscape:
         quadrants = len(emptyCells)
         if totalCells == 0:
             return
-        if len(self.agents) + numAgents > totalCells:
+        if numAgents > totalCells:
             if "all" in self.debug or "sugarscape" in self.debug:
                 print(f"Could not allocate {numAgents} agents. Allocating maximum of {totalCells}.")
             numAgents = totalCells
@@ -215,8 +215,6 @@ class Sugarscape:
         self.environment.findCellRanges()
 
     def doTimestep(self):
-        self.removeDeadAgents()
-        self.replaceDeadAgents()
         if self.timestep >= self.maxTimestep:
             self.toggleEnd()
             return
@@ -231,6 +229,7 @@ class Sugarscape:
             for agent in self.agents:
                 agent.doTimestep(self.timestep)
             self.removeDeadAgents()
+            self.replaceDeadAgents()
             self.updateRuntimeStats()
             if self.gui != None:
                 self.updateGraphStats()
@@ -628,8 +627,6 @@ class Sugarscape:
         if numAgents < self.configuration["agentReplacements"]:
             numReplacements = self.configuration["agentReplacements"] - numAgents
             self.configureAgents(numReplacements)
-            if self.gui != None:
-                self.gui.doTimestep()
 
     def runSimulation(self, timesteps=5):
         self.startLog()

--- a/sugarscape.py
+++ b/sugarscape.py
@@ -630,6 +630,8 @@ class Sugarscape:
 
     def runSimulation(self, timesteps=5):
         self.startLog()
+        if self.log == None:
+            self.updateRuntimeStats()
         if self.gui != None:
             # Simulation begins paused until start button in GUI pressed
             self.gui.updateLabels()


### PR DESCRIPTION
One of my configs with 300 initial and 300 replacement agents was jumping up to 492 agents. `totalCells` is the number of empty spawning locations, not the total number of spawn locations.

I moved agent replacements to before the GUI draw so that the number of agents on screen and the GUI agent counter are always equal to the replacement agents (if 300, there will always be 300 agents on screen). You might prefer that agents are replaced after the GUI draw (the current behavior) so that you still get a sense of how many agents died last timestep (# replacements - agent counter on GUI). In that case, the other changes—removing the extra GUI draw and correcting the number of configured agents—should still stay.

I'm also thinking that we should `updateRuntimeStats` once after creating the GUI and before running any `sugarscape.doTimestep` so that the counters on the menu bar are not all incorrectly 0 at timestep 0. They are correct if logging is enabled because we `updateRuntimeStats` at the beginning of `startLog`, but they should be updated even if there is no log.