### PR TITLE
Fixes environment not appearing on certain computers

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -277,7 +277,7 @@ class GUI:
 
         # Adjust for slight deviations from initially configured window size
         self.resizeInterface()
-        window.update()
+        window.update_idletasks()
 
     def deleteLines(self):
         self.canvas.delete("line")


### PR DESCRIPTION
The environment was being configured before the initial window resize since the resize was being deferred by the window manager.