### PR TITLE
Fixes divide-by-zero break when maxFriends is 0

### DIFF
--- a/agent.py
+++ b/agent.py
@@ -1004,6 +1004,8 @@ class Agent:
         return retaliators
 
     def findSocialHappiness(self):
+        if self.maxFriends == 0:
+            return 0
         step = 2 / self.maxFriends
         return (len(self.socialNetwork["friends"]) * step) - 1
 


### PR DESCRIPTION
Default value could alternatively be 0.5 or 1.